### PR TITLE
feat: support static partial application definitions

### DIFF
--- a/src/factories/common.js
+++ b/src/factories/common.js
@@ -38,3 +38,7 @@ export const nft = (...weights) =>
   ])
 export const nullOrFake = (fakeFn, nullWeight = 0.5) =>
   faker.datatype.boolean(nullWeight) ? null : fakeFn()
+
+// replicate non-standard kits date format, e.g. '2019-01-30T12:25:23:023+0000'
+// NOTE: the seconds:milliseconds separator is a colon `:`, not a dot `.` !!
+export const transformDate = (date) => date.toISOString().replace('.', ':')

--- a/src/factories/id-lookups.js
+++ b/src/factories/id-lookups.js
@@ -97,7 +97,7 @@ export const personIdToCRN = {
   5069674: '1100696741'
 }
 
-const orgIdLookup = {
+export const orgIdLookup = {
   1000000000: {
     sbi: 1000000000,
     customers: [] // org with no customers
@@ -122,6 +122,7 @@ const orgIdLookup = {
       22222277, 22222278, 22222279
     ]
   },
+  // SFD requested
   5583575: { sbi: 107167406, customers: [5007704] },
   5578463: { sbi: 107097991, customers: [5010242] },
   5501559: { sbi: 106354662, customers: [5002139] },
@@ -147,7 +148,15 @@ const orgIdLookup = {
   5705812: { sbi: 200089578, customers: [5042346] },
   5783443: { sbi: 200384417, customers: [5042346] },
   5374662: { sbi: 114301879, customers: [5069674] },
-  5467167: { sbi: 106430700, customers: [5069674] }
+  5467167: { sbi: 106430700, customers: [5069674] },
+  // temporarily add v1 data for testing Applications
+  5565448: { sbi: 107183280, customers: [], applications: [{ application_history: [{}] }] }, // 1 app
+  5559799: { sbi: 106238988, customers: [] },
+  5560725: { sbi: 106284736, customers: [] },
+  5625145: { sbi: 107591843, customers: [] },
+  5447505: { sbi: 121428499, customers: [] },
+  9000001: { sbi: 900000001, customers: [] },
+  9000002: { sbi: 900000002, customers: [] }
 }
 
 // Derived inverses — calculated once

--- a/src/factories/siti-agri/application.factory.js
+++ b/src/factories/siti-agri/application.factory.js
@@ -1,5 +1,5 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
-import { fakeId, nullOrFake } from '../common.js'
+import { fakeId, nullOrFake, transformDate } from '../common.js'
 import { orgIdLookup, sbiToOrgId } from '../id-lookups.js'
 
 const applications = {}
@@ -68,7 +68,7 @@ const intermediateTransitions = [
 ]
 
 export const createHistory = (overrides = {}) => ({
-  dt_transition: faker.date.recent().toISOString(),
+  dt_transition: transformDate(faker.date.recent()),
   check_status: faker.helpers.weightedArrayElement([
     { weight: 14, value: 'PASSED' },
     { weight: 1, value: 'NOT PASSED' }
@@ -129,7 +129,7 @@ export const createApplication = (sbi, overrides = {}) => {
     status_code_p: 'STADOM', // always seems to be 'STADOM'
     status_code_s: code,
     status,
-    submission_date: faker.date.recent().toISOString(),
+    submission_date: transformDate(faker.date.recent()),
     portal_status_p: 'DOMPRS', // always seems to be 'DOMPRS'
     // portal_status_s is often `null`, otherwise follows normal pattern from mappings
     portal_status_s: nullOrFake(() => portal, 0.2),

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -1,9 +1,9 @@
 import { health } from '../routes/health.js'
 import { authenticate } from '../routes/rural-payments/authenticate.js'
-import { person } from '../routes/rural-payments/person.js'
-import { organisation } from '../routes/rural-payments/organisation.js'
 import { lms } from '../routes/rural-payments/lms.js'
 import { notifications } from '../routes/rural-payments/messages.js'
+import { organisation } from '../routes/rural-payments/organisation.js'
+import { person } from '../routes/rural-payments/person.js'
 import { sitiAgri } from '../routes/rural-payments/siti-agri.js'
 import { sitiagri } from '../routes/v2/siti-agri.js'
 
@@ -19,7 +19,10 @@ const router = {
         ...lms,
         ...notifications,
         ...sitiAgri,
-        ...sitiagri
+        ...sitiagri.map((route) => ({
+          ...route,
+          path: `/v1${route.path}` // change path to v1
+        }))
       ])
     }
   }

--- a/src/routes/v2/siti-agri-schema.oas.yml
+++ b/src/routes/v2/siti-agri-schema.oas.yml
@@ -105,6 +105,11 @@ components:
         status:
           type: string
         submission_date:
+          oneOf:
+            - type: string
+              pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}:\d{3}(?:Z|\+\d{2}:?\d{2})$'
+              example: '2019-01-30T12:25:23:023+0000'
+            - type: 'null'
           type: [string, 'null']
         portal_status_p:
           type: string
@@ -149,6 +154,8 @@ components:
       properties:
         dt_transition:
           type: string
+          pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}:\d{3}(?:Z|\+\d{2}:?\d{2})$'
+          example: '2019-01-30T12:25:23:023+0000'
         check_status:
           type: string
         transition_id:

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -50,36 +50,29 @@ fi
 case "$1" in
   p | person)
     schema="person"
-    mutations='
-. |
-.schemes = "https" |
-.paths["/person/{personId}/summary"].get.parameters[0]["x-examples"] = [5858232,5108985,5108989] |
-.definitions.PartySearchRequest["x-examples"][0].primarySearchPhrase = "1105658066" |
-.definitions.PartySearchRequest["x-examples"][1].primarySearchPhrase = "1101089857" |
-.definitions.PartySearchRequest["x-examples"][2].primarySearchPhrase = "1101089899"'
+    mutations='. |
+.paths["/person/{personId}/summary"].get.parameters[0].schema.examples] = [5858232,5108985,5108989] |
+.components.schemas.PartySearchRequest["x-examples"][0].primarySearchPhrase = "1105658066" |
+.components.schemas.PartySearchRequest["x-examples"][1].primarySearchPhrase = "1101089857" |
+.components.schemas.PartySearchRequest["x-examples"][2].primarySearchPhrase = "1101089899"'
     ;;
   o | org | organisation)
     schema="organisation"
-    mutations='
-. |
-.schemes[0] = "https" |
-.paths["/organisation/{organisationId}"].get.parameters[0]["x-examples"] = [5491723,5680131,5849659,5852711,5858233 ] |
-.definitions.PartySearchRequest["x-examples"][0].primarySearchPhrase = "106554744" |
-.definitions.PartySearchRequest["x-examples"][1].primarySearchPhrase = "200629003" |
-.definitions.PartySearchRequest["x-examples"][2].primarySearchPhrase = "200665008"'
+    mutations='. |
+.paths["/organisation/{organisationId}"].get.parameters[0].schema.examples = [5491723,5680131,5849659,5852711,5858233 ] |
+.components.schemas.PartySearchRequest["x-examples"][0].primarySearchPhrase = "106554744" |
+.components.schemas.PartySearchRequest["x-examples"][1].primarySearchPhrase = "200629003" |
+.components.schemas.PartySearchRequest["x-examples"][2].primarySearchPhrase = "200665008"'
     ;;
   a | auth | authenticate )
     schema="authenticate"
-    mutations='
-. |
-.schemes[0] = "https" |
+    mutations='. |
 .paths["/external-auth/security-answers/{crn}"].get.parameters[0].pattern = "^[1-9][0-9]{9,19}$" |
-.paths["/external-auth/security-answers/{crn}"].get.parameters[0]["x-examples"] = [1105739979,1106046692,1106077237,1100932879,1105430162]'
+.paths["/external-auth/security-answers/{crn}"].get.parameters[0].schema.examples] = [1105739979,1106046692,1106077237,1100932879,1105430162]'
     ;;
   s | sa | siti-agri)
     schema="siti-agri"
-    mutations='
-. |
+    mutations='. |
 .paths["/SitiAgriApi/cv/appByBusiness/sbi/{sbi}/list"].get.parameters[0].schema.examples = [121174131,200697200,107120488,117713636,200694241,200721391,119897756]'
     ;;
   h | help | --help | -h)

--- a/test/integration/siti-agri/applications.test.js
+++ b/test/integration/siti-agri/applications.test.js
@@ -13,10 +13,10 @@ describe('Fake Authenticate data', () => {
     ])
   })
 
-  it('should GET applications data conforming to the schema', async () => {
+  it('should GET fake applications data conforming to the schema', async () => {
     const { result, statusCode } = await server.inject({
       method: 'GET',
-      url: '/SitiAgriApi/cv/appByBusiness/sbi/1111111111/list'
+      url: '/SitiAgriApi/cv/appByBusiness/sbi/2222222222/list'
     })
     expect(statusCode).toBe(200)
     expect(result).toConformToSchema(
@@ -24,5 +24,25 @@ describe('Fake Authenticate data', () => {
         'application/json'
       ].schema
     )
+  })
+
+  it('should GET applications data with overrides defined in the id-lookups', async () => {
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: '/SitiAgriApi/cv/appByBusiness/sbi/107183280/list'
+    })
+    expect(statusCode).toBe(200)
+    expect(result).toConformToSchema(
+      schema.paths['/SitiAgriApi/cv/appByBusiness/sbi/{sbi}/list'].get.responses['200'].content[
+        'application/json'
+      ].schema
+    )
+    expect(result.data.length).toBe(1)
+
+    const app = result.data[0]
+    expect(app.application_history.length).toBe(1)
+    const history = app.application_history[0]
+    expect(history.transition_name).toBe(app.transition_name)
+    expect(history.transition_id).toBe(app.transition_id)
   })
 })


### PR DESCRIPTION
Adds ability to partially define applications in the `id-lookups.js` file, along with the other data relations.
e.g. the following creates a single faked application with a single (also faked) history:
```js
  5565448: {
    sbi: 107183280,
    customers: [],
    applications: [{ // override standard behaviour to add an application
      application_history: [{}] // ...and a history item
    }]
  }
```
This allows simple test data to be reliably created, from very little, but also supports explicitly setting values if strictly necessary.