### PR TITLE
chore: speed up linting, by skipping v1 OASs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,5 +11,5 @@ export default defineConfig([
       }
     }
   },
-  globalIgnores(['coverage'])
+  globalIgnores(['coverage', 'version1-open-api-spec'])
 ])


### PR DESCRIPTION
Once the fixtures are removed too (as they're no longer needed), linting should be lightening fast again :zap: 