### PR TITLE
feat: Add support for validateEmail endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
+      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -3202,9 +3202,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3900,9 +3900,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -8134,9 +8134,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/src/routes/kits-v1/person-schema.oas.yml
+++ b/src/routes/kits-v1/person-schema.oas.yml
@@ -51,6 +51,39 @@ paths:
         '404':
           description: 'Person not found'
           $ref: '#/components/responses/NotFound'
+  /person/{emailAddress}/validateEmail:
+    get:
+      tags:
+        - 'person'
+      summary: 'Validates emails'
+      description: 'Returns a boolean to indicate if the email is duplicated'
+      operationId: 'isEmailDuplicated'
+      parameters:
+        - name: 'emailAddress'
+          in: 'path'
+          description: 'email'
+          required: true
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'Returns a flag to indicate if the email is a duplicate'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  _data:
+                    $ref: '#/components/schemas/ValidEmail'
+                required:
+                  - '_data'
+                additionalProperties: false
+        '403':
+          description: Getting an internal user's details is forbidden, or a WAF rule has been triggered.
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 'Person not found'
+          $ref: '#/components/responses/NotFound'
   /person/search:
     post:
       tags:
@@ -485,6 +518,14 @@ components:
         - 'customerReferenceNumber'
         - 'personalIdentifiers'
         - 'deactivated'
+    ValidEmail:
+      type: object
+      additionalProperties: false
+      properties:
+        emailDuplicated:
+          type: boolean
+      required:
+        - 'emailDuplicated'
 
   securitySchemes:
     mTLS:

--- a/src/routes/kits-v1/person.js
+++ b/src/routes/kits-v1/person.js
@@ -27,6 +27,24 @@ const checkPersonId = (request) => {
   return personId
 }
 
+const validateEmailAddress = (emailAddress) => {
+  const localPart = emailAddress.split('@')[0]
+
+  // If the local part of the email is a number in (a selection of) the 4XX/5XX range, then return that as a status code
+  if (Number.isInteger(Number(localPart))) {
+    const statusCode = Number(localPart)
+
+    // Keeping the implementation simple here, only supporting a small subset of status codes.
+    // All other numbers treated as a valid email address
+    const validStatusCode = new Set([400, 401, 403, 404, 500]).has(statusCode)
+    if (validStatusCode) {
+      throw new Boom.Boom(`Simulated service failure with status code ${validStatusCode}`, {
+        statusCode: statusCode
+      })
+    }
+  }
+}
+
 export const person = [
   {
     method: 'GET',
@@ -42,6 +60,18 @@ export const person = [
       const { role, privileges, lastUpdatedOn, ...personData } = retrievePerson(personId)
 
       return h.response({ _data: personData })
+    }
+  },
+  {
+    method: 'GET',
+    path: '/person/{emailAddress}/validateEmail',
+    handler: async (request, h) => {
+      const emailAddress = request.params.emailAddress
+
+      validateEmailAddress(emailAddress)
+
+      const emailDuplicated = emailAddress.includes('exists')
+      return h.response({ _data: { emailDuplicated } })
     }
   },
   {

--- a/test/integration/routes/person/person.test.js
+++ b/test/integration/routes/person/person.test.js
@@ -40,6 +40,37 @@ describe('Fake Person', () => {
     )
   })
 
+  describe('validateEmail', () => {
+    it('returns emailDuplicated: true when the address contains "exists"', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/person/test.exists@example.com/validateEmail'
+      })
+      expect(statusCode).toBe(200)
+      expect(result._data.emailDuplicated).toBe(true)
+    })
+
+    it('returns emailDuplicated: false when the address does not contain "exists"', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/person/test@example.com/validateEmail'
+      })
+      expect(statusCode).toBe(200)
+      expect(result._data.emailDuplicated).toBe(false)
+    })
+
+    it.each([400, 401, 403, 404, 500])(
+      'returns http status code %i when local part of email is %i',
+      async (code) => {
+        const { statusCode } = await server.inject({
+          method: 'GET',
+          url: `/person/${code}@example.com/validateEmail`
+        })
+        expect(statusCode).toBe(code)
+      }
+    )
+  })
+
   it('should fetch the same person with ID or CRN', async () => {
     const id = 11111111
     const { result, statusCode } = await server.inject({


### PR DESCRIPTION
Generates a http status error if the local part of the email contains one of the following status codes:
> 400, 401, 403, 404 & 500

Returns a response indicating that the email address exists in the system, if the email address contains the substring "exists"

Otherwise, returns a response indicating that the supplied email address does not exist in the system