### PR TITLE
feat: Add proxy to allow KITS API endpoints to be accessed

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ More information about each logical area of the API can be found by accessing it
 | `GET: /schemata/person.yml`       | Defines the API for `person` data at `/extapi/person`                                                                                            |
 | `GET: /schemata/siti-agri.yml`    | Defines the API for `Siti-Agri` data at `/SitiAgriApi/cv`                                                                                        |
 
+## Schema testing against the KITS upgrade endpoint
+
+It's not possible to directly access the KITS service from a developer machine. The mock service can be used as a proxy
+to the KITS service, allowing schema verification. Access to this AI is via the CDP ephemeral gateway using a
+[developer API key](https://github.com/DEFRA/cdp-documentation/blob/main/how-to/developer-api-key.md) (valid for 24 hours).
+You can then access the proxy as shown in the following example
+
+> curl --header 'x-api-key: {API-KEY}' --header 'email: {EMAIL-ADDRESS}' https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi/person/3010037/summary
+
 ## Docker
 
 ### Development image

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ More information about each logical area of the API can be found by accessing it
 | `GET: /schemata/person.yml`       | Defines the API for `person` data at `/extapi/person`                                                                                            |
 | `GET: /schemata/siti-agri.yml`    | Defines the API for `Siti-Agri` data at `/SitiAgriApi/cv`                                                                                        |
 
-## Schema testing against the KITS upgrade endpoint
+## Schema testing against the KITS upgrade service
 
 It's not possible to directly access the KITS service from a developer machine. The mock service can be used as a proxy
-to the KITS service, allowing schema verification. Access to this AI is via the CDP ephemeral gateway using a
+to the KITS service, allowing schema verification. Access to this API is via the CDP ephemeral gateway using a
 [developer API key](https://github.com/DEFRA/cdp-documentation/blob/main/how-to/developer-api-key.md) (valid for 24 hours).
 You can then access the proxy as shown in the following example
 

--- a/compose-proxy-downstream.yml
+++ b/compose-proxy-downstream.yml
@@ -1,0 +1,16 @@
+services:
+  # Extends the DAL mock to support client-side MTLS configuration (should be run as part of ./scripts/run-dal-downstream-and-mtls-kits-upstream.sh)
+  dal-mock:
+    environment:
+      KITS_CA_CERT: ${KITS_CA_CERT:?KITS_CA_CERT must be set for kits emulation}
+      KITS_INTERNAL_GATEWAY_URL: https://kits-emulation-mock:3101/extapi
+      KITS_INTERNAL_CONNECTION_KEY: ${KITS_INTERNAL_CONNECTION_KEY:?KITS_INTERNAL_CONNECTION_KEY must be set}
+      KITS_INTERNAL_CONNECTION_CERT: ${KITS_INTERNAL_CONNECTION_CERT:?KITS_INTERNAL_CONNECTION_CERT must be set}
+      KITS_EXTERNAL_GATEWAY_URL: https://kits-emulation-mock:3101/extapi
+      KITS_EXTERNAL_CONNECTION_KEY: $KITS_INTERNAL_CONNECTION_KEY
+      KITS_EXTERNAL_CONNECTION_CERT: $KITS_INTERNAL_CONNECTION_CERT
+
+    volumes:
+      - ./scripts/mtls/ca.crt:/tmp/ca.crt:ro
+      - ./scripts/mtls/client.crt:/tmp/client.crt:ro
+      - ./scripts/mtls/client.key:/tmp/client.key:ro

--- a/compose-proxy-downstream.yml
+++ b/compose-proxy-downstream.yml
@@ -3,10 +3,10 @@ services:
   dal-mock:
     environment:
       KITS_CA_CERT: ${KITS_CA_CERT:?KITS_CA_CERT must be set for kits emulation}
-      KITS_INTERNAL_GATEWAY_URL: https://kits-proxied-upstream:3101/extapi
+      KITS_INTERNAL_GATEWAY_URL: https://mtls-protected-upstream-simulator:3101/extapi
       KITS_INTERNAL_CONNECTION_KEY: ${KITS_INTERNAL_CONNECTION_KEY:?KITS_INTERNAL_CONNECTION_KEY must be set}
       KITS_INTERNAL_CONNECTION_CERT: ${KITS_INTERNAL_CONNECTION_CERT:?KITS_INTERNAL_CONNECTION_CERT must be set}
-      KITS_EXTERNAL_GATEWAY_URL: https://kits-proxied-upstream:3101/extapi
+      KITS_EXTERNAL_GATEWAY_URL: https://mtls-protected-upstream-simulator:3101/extapi
       KITS_EXTERNAL_CONNECTION_KEY: $KITS_INTERNAL_CONNECTION_KEY
       KITS_EXTERNAL_CONNECTION_CERT: $KITS_INTERNAL_CONNECTION_CERT
 

--- a/compose-proxy-downstream.yml
+++ b/compose-proxy-downstream.yml
@@ -3,10 +3,10 @@ services:
   dal-mock:
     environment:
       KITS_CA_CERT: ${KITS_CA_CERT:?KITS_CA_CERT must be set for kits emulation}
-      KITS_INTERNAL_GATEWAY_URL: https://kits-emulation-mock:3101/extapi
+      KITS_INTERNAL_GATEWAY_URL: https://kits-proxied-upstream:3101/extapi
       KITS_INTERNAL_CONNECTION_KEY: ${KITS_INTERNAL_CONNECTION_KEY:?KITS_INTERNAL_CONNECTION_KEY must be set}
       KITS_INTERNAL_CONNECTION_CERT: ${KITS_INTERNAL_CONNECTION_CERT:?KITS_INTERNAL_CONNECTION_CERT must be set}
-      KITS_EXTERNAL_GATEWAY_URL: https://kits-emulation-mock:3101/extapi
+      KITS_EXTERNAL_GATEWAY_URL: https://kits-proxied-upstream:3101/extapi
       KITS_EXTERNAL_CONNECTION_KEY: $KITS_INTERNAL_CONNECTION_KEY
       KITS_EXTERNAL_CONNECTION_CERT: $KITS_INTERNAL_CONNECTION_CERT
 

--- a/compose-proxy-upstream.yml
+++ b/compose-proxy-upstream.yml
@@ -1,7 +1,7 @@
 services:
   # Starts the DAL, with upstream/server MTLS configuration.  This is primarily intended to act as the upstream
   # endpoint for the /proxy endpoint in the mock.
-  kits-proxied-upstream:
+  mtls-protected-upstream-simulator:
     build:
       context: .
     environment:

--- a/compose-proxy-upstream.yml
+++ b/compose-proxy-upstream.yml
@@ -1,0 +1,26 @@
+services:
+  # Starts the DAL, with upstream/server MTLS configuration.  This is primarily
+  kits-emulation-mock:
+    build:
+      context: .
+    environment:
+      MOCK_LOG_LEVEL: info
+      NODE_ENV: production
+      PORT: 3101
+      TLS_KEY: ${KITS_MOCK_TLS_SERVER_KEY:?KITS_MOCK_TLS_SERVER_KEY must be set for kits emulation}
+      TLS_CERT: ${KITS_MOCK_TLS_SERVER_CERT:?KITS_MOCK_TLS_SERVER_CERT must be set for kits emulation}
+      TLS_CA: ${KITS_CA_CERT:?KITS_CA_CERT must be set for kits emulation}
+    ports:
+      - '3101:3101'
+    healthcheck:
+      test: curl -s --cacert /tmp/ca.crt --key /tmp/client.key --cert /tmp/client.crt https://localhost:3101/health > /tmp/start.log 2>&1
+    volumes:
+      - ./scripts/mtls/ca.crt:/tmp/ca.crt:ro
+      - ./scripts/mtls/client.crt:/tmp/client.crt:ro
+      - ./scripts/mtls/client.key:/tmp/client.key:ro
+    networks:
+      - default
+
+networks:
+  default:
+    driver: bridge

--- a/compose-proxy-upstream.yml
+++ b/compose-proxy-upstream.yml
@@ -1,6 +1,7 @@
 services:
-  # Starts the DAL, with upstream/server MTLS configuration.  This is primarily
-  kits-emulation-mock:
+  # Starts the DAL, with upstream/server MTLS configuration.  This is primarily intended to act as the upstream
+  # endpoint for the /proxy endpoint in the mock.
+  kits-proxied-upstream:
     build:
       context: .
     environment:

--- a/kits-upstream-proxy.md
+++ b/kits-upstream-proxy.md
@@ -68,7 +68,7 @@ This generates certificates/keys needed to support MTLS and then starts two dock
   - Proxy Endpoint
     - /proxy
       - This uses MTLS to communicates with the KITS emulation docker image below
-- The MTLS secured KITS simulator (kits-proxied-upstream), used as the upstream for the standard mock above
+- The MTLS secured KITS simulator (mtls-protected-upstream-simulator), used as the upstream for the standard mock above
 
 You can the access the KITS-emulator via the DAL mock proxy as follows:
 

--- a/kits-upstream-proxy.md
+++ b/kits-upstream-proxy.md
@@ -93,11 +93,3 @@ npm run dev-with-locally-proxied-kits
 You can then access the service on port 3001 as follows
 
 > curl http://localhost:3001/proxy/external/extapi/person/3010037/summary
-
-### Accessing the mock proxy in CDP Dev environment
-
-It is not possible to directly access the deployed API, from your local machine. Instead, you need to access the
-API via the ephemeral gateway using a [developer API key](https://github.com/DEFRA/cdp-documentation/blob/main/how-to/developer-api-key.md)
-(valid for 24 hours). You can then access the proxy as follows
-
-> curl --header 'x-api-key: {API-KEY}' https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi/person/3010037/summary

--- a/kits-upstream-proxy.md
+++ b/kits-upstream-proxy.md
@@ -67,10 +67,10 @@ This generates certificates/keys needed to support MTLS and then starts two dock
     - /extapi
   - Proxy Endpoint
     - /proxy
-      - This uses MTLS to communicates with the KITS emulation docker image below
+      - This uses MTLS to communicate with the KITS emulation docker image below
 - The MTLS secured KITS simulator (mtls-protected-upstream-simulator), used as the upstream for the standard mock above
 
-You can the access the KITS-emulator via the DAL mock proxy as follows:
+You can then access the KITS-emulator via the DAL mock proxy as follows:
 
 > curl http://localhost:3100/proxy/internal/extapi/person/3010037/summary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "hapi-pino": "^13.0.0",
         "hapi-pulse": "^3.0.1",
         "pino": "^10.0.0",
-        "pino-pretty": "^13.0.0"
+        "pino-pretty": "^13.0.0",
+        "undici": "^7.18.2"
       },
       "devDependencies": {
         "@redocly/cli": "^2.11.1",
@@ -970,9 +971,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
+      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -1794,6 +1795,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -2221,6 +2235,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/undici": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@redocly/config": {
@@ -3202,9 +3226,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3900,9 +3924,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -4658,9 +4682,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "dev": true,
       "funding": [
         {
@@ -4674,9 +4698,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "dev": true,
       "funding": [
         {
@@ -4686,9 +4710,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -7688,9 +7713,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "dev": true,
       "funding": [
         {
@@ -8134,9 +8159,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -9230,9 +9255,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "dev": true,
       "funding": [
         {
@@ -9658,13 +9683,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
-      "dev": true,
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development nodemon --ext js,json -w ./src",
+    "dev-with-locally-proxied-kits": "NODE_ENV=development dotenv -e .env.mtls -- nodemon --ext js,json -w ./src",
     "git:pre-commit-hook": "npm run lint",
     "postinstall": "npm run setup:husky",
     "lint": "eslint . && prettier --check . && npm run verify:schemata",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "hapi-pino": "^13.0.0",
     "hapi-pulse": "^3.0.1",
     "pino": "^10.0.0",
-    "pino-pretty": "^13.0.0"
+    "pino-pretty": "^13.0.0",
+    "undici": "^7.18.2"
   },
   "devDependencies": {
     "@redocly/cli": "^2.11.1",

--- a/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
+++ b/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
@@ -10,7 +10,7 @@ cd "${PROJECT_ROOT}"
 # Generate TLS assets
 echo "Generating TLS assets..."
 rm -fr "${SCRIPT_DIR}/mtls"
-"${SCRIPT_DIR}/setup-mtls.sh" kits-proxied-upstream
+"${SCRIPT_DIR}/setup-mtls.sh" mtls-protected-upstream-simulator
 
 # Load env variables from generated TLS assets
 export KITS_CA_CERT="$(cat "${SCRIPT_DIR}/mtls/ca.crt" | base64 -w0)"

--- a/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
+++ b/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+# Get main directories, and switch to project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+# Generate TLS assets
+echo "Generating TLS assets..."
+rm -fr "${SCRIPT_DIR}/mtls"
+"${SCRIPT_DIR}/setup-mtls.sh" kits-emulation-mock
+
+## Load env variables from generated TLS assets
+export KITS_CA_CERT="$(cat "${SCRIPT_DIR}/mtls/ca.crt" | base64 -w0)"
+export KITS_MOCK_TLS_SERVER_KEY="$(cat "${SCRIPT_DIR}/mtls/server.key" | base64 -w0)"
+export KITS_MOCK_TLS_SERVER_CERT="$(cat "${SCRIPT_DIR}/mtls/server.crt" | base64 -w0)"
+export KITS_INTERNAL_CONNECTION_KEY="$(cat "${SCRIPT_DIR}/mtls/client.key" | base64 -w0)"
+export KITS_INTERNAL_CONNECTION_CERT="$(cat "${SCRIPT_DIR}/mtls/client.crt" | base64 -w0)"
+#
+## Run docker compose
+echo
+echo "Starting CDP emulation..."
+docker compose \
+  -f "${PROJECT_ROOT}/compose.yml" \
+  ${TEST_CONTAINER[@]} \
+  -f "${PROJECT_ROOT}/compose-proxy-upstream.yml" \
+  -f "${PROJECT_ROOT}/compose-proxy-downstream.yml" \
+  up \
+  --build --quiet-pull \
+  ${COMPOSE_SERVICE}
+
+# clean-up generated TLS assets
+echo
+echo "Cleaning up TLS assets..."
+rm -fr "${SCRIPT_DIR}/mtls"

--- a/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
+++ b/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
@@ -10,16 +10,16 @@ cd "${PROJECT_ROOT}"
 # Generate TLS assets
 echo "Generating TLS assets..."
 rm -fr "${SCRIPT_DIR}/mtls"
-"${SCRIPT_DIR}/setup-mtls.sh" kits-emulation-mock
+"${SCRIPT_DIR}/setup-mtls.sh" kits-proxied-upstream
 
-## Load env variables from generated TLS assets
+# Load env variables from generated TLS assets
 export KITS_CA_CERT="$(cat "${SCRIPT_DIR}/mtls/ca.crt" | base64 -w0)"
 export KITS_MOCK_TLS_SERVER_KEY="$(cat "${SCRIPT_DIR}/mtls/server.key" | base64 -w0)"
 export KITS_MOCK_TLS_SERVER_CERT="$(cat "${SCRIPT_DIR}/mtls/server.crt" | base64 -w0)"
 export KITS_INTERNAL_CONNECTION_KEY="$(cat "${SCRIPT_DIR}/mtls/client.key" | base64 -w0)"
 export KITS_INTERNAL_CONNECTION_CERT="$(cat "${SCRIPT_DIR}/mtls/client.crt" | base64 -w0)"
-#
-## Run docker compose
+
+# Run docker compose
 echo
 echo "Starting CDP emulation..."
 docker compose \

--- a/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
+++ b/scripts/run-dal-downstream-and-mtls-kits-upstream.sh
@@ -21,15 +21,13 @@ export KITS_INTERNAL_CONNECTION_CERT="$(cat "${SCRIPT_DIR}/mtls/client.crt" | ba
 
 # Run docker compose
 echo
-echo "Starting CDP emulation..."
+echo "Starting MTLS protected upstream & downstream..."
 docker compose \
   -f "${PROJECT_ROOT}/compose.yml" \
-  ${TEST_CONTAINER[@]} \
   -f "${PROJECT_ROOT}/compose-proxy-upstream.yml" \
   -f "${PROJECT_ROOT}/compose-proxy-downstream.yml" \
   up \
-  --build --quiet-pull \
-  ${COMPOSE_SERVICE}
+  --build --quiet-pull
 
 # clean-up generated TLS assets
 echo

--- a/scripts/run-proxy-upstream-with-mtls-kits.sh
+++ b/scripts/run-proxy-upstream-with-mtls-kits.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+# Get main directories, and switch to project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+# Generate TLS assets
+echo "Generating TLS assets..."
+rm -fr "${SCRIPT_DIR}/mtls"
+${SCRIPT_DIR}/setup-mtls.sh
+
+## Load env variables from generated TLS assets
+export KITS_CA_CERT="$(cat "${SCRIPT_DIR}/mtls/ca.crt" | base64 -w0)"
+export KITS_MOCK_TLS_SERVER_KEY="$(cat "${SCRIPT_DIR}/mtls/server.key" | base64 -w0)"
+export KITS_MOCK_TLS_SERVER_CERT="$(cat "${SCRIPT_DIR}/mtls/server.crt" | base64 -w0)"
+export KITS_INTERNAL_CONNECTION_KEY="$(cat "${SCRIPT_DIR}/mtls/client.key" | base64 -w0)"
+export KITS_INTERNAL_CONNECTION_CERT="$(cat "${SCRIPT_DIR}/mtls/client.crt" | base64 -w0)"
+#
+## Run docker compose
+echo
+echo "Starting CDP emulation..."
+docker compose \
+  -f "${PROJECT_ROOT}/compose-proxy-upstream.yml" \
+  ${TEST_CONTAINER[@]} \
+  up \
+  --build --quiet-pull \
+  ${COMPOSE_SERVICE}
+
+# clean-up generated TLS assets
+echo
+echo "Cleaning up TLS assets..."
+rm -fr "${SCRIPT_DIR}/mtls"

--- a/scripts/run-proxy-upstream-with-mtls-kits.sh
+++ b/scripts/run-proxy-upstream-with-mtls-kits.sh
@@ -12,14 +12,14 @@ echo "Generating TLS assets..."
 rm -fr "${SCRIPT_DIR}/mtls"
 ${SCRIPT_DIR}/setup-mtls.sh
 
-## Load env variables from generated TLS assets
+# Load env variables from generated TLS assets
 export KITS_CA_CERT="$(cat "${SCRIPT_DIR}/mtls/ca.crt" | base64 -w0)"
 export KITS_MOCK_TLS_SERVER_KEY="$(cat "${SCRIPT_DIR}/mtls/server.key" | base64 -w0)"
 export KITS_MOCK_TLS_SERVER_CERT="$(cat "${SCRIPT_DIR}/mtls/server.crt" | base64 -w0)"
 export KITS_INTERNAL_CONNECTION_KEY="$(cat "${SCRIPT_DIR}/mtls/client.key" | base64 -w0)"
 export KITS_INTERNAL_CONNECTION_CERT="$(cat "${SCRIPT_DIR}/mtls/client.crt" | base64 -w0)"
-#
-## Run docker compose
+
+# Run docker compose
 echo
 echo "Starting CDP emulation..."
 docker compose \

--- a/scripts/run-proxy-upstream-with-mtls-kits.sh
+++ b/scripts/run-proxy-upstream-with-mtls-kits.sh
@@ -24,7 +24,6 @@ echo
 echo "Starting MTLS protected upstream..."
 docker compose \
   -f "${PROJECT_ROOT}/compose-proxy-upstream.yml" \
-  ${TEST_CONTAINER[@]} \
   up \
   --build --quiet-pull
 

--- a/scripts/run-proxy-upstream-with-mtls-kits.sh
+++ b/scripts/run-proxy-upstream-with-mtls-kits.sh
@@ -21,13 +21,12 @@ export KITS_INTERNAL_CONNECTION_CERT="$(cat "${SCRIPT_DIR}/mtls/client.crt" | ba
 
 # Run docker compose
 echo
-echo "Starting CDP emulation..."
+echo "Starting MTLS protected upstream..."
 docker compose \
   -f "${PROJECT_ROOT}/compose-proxy-upstream.yml" \
   ${TEST_CONTAINER[@]} \
   up \
-  --build --quiet-pull \
-  ${COMPOSE_SERVICE}
+  --build --quiet-pull
 
 # clean-up generated TLS assets
 echo

--- a/scripts/setup-mtls.sh
+++ b/scripts/setup-mtls.sh
@@ -134,16 +134,11 @@ run_command openssl req -new \
     -key ./mtls/server.key -passin pass:server-password \
     -out ./mtls/server.csr -subj '/CN='"${COMMON_NAME}"
 
-# Write the SAN extension to a file rather than using -addext, which requires OpenSSL 1.1.1+
-# and is not supported on macOS's bundled LibreSSL.
-echo "subjectAltName=DNS:${COMMON_NAME}" > ./mtls/server.ext
-
 run_command openssl x509 -req \
     -in ./mtls/server.csr -out ./mtls/server.crt \
     -CA ${CA_CERT} -CAkey ${CA_KEY} -passin pass:ca-password \
     -CAcreateserial -CAserial ./mtls/ca.srl \
-    -days ${TEST_ASSET_TTL} \
-    -extfile ./mtls/server.ext
+    -days ${TEST_ASSET_TTL}
 
 # setup client assets
 run_command openssl genpkey \
@@ -161,7 +156,7 @@ run_command openssl x509 -req \
     -days ${TEST_ASSET_TTL}
 
 # tidy up - remove CSR files
-run_command rm ./mtls/*.csr ./mtls/*.ext
+run_command rm ./mtls/*.csr
 
 echo "MTLS setup complete"
 

--- a/scripts/setup-mtls.sh
+++ b/scripts/setup-mtls.sh
@@ -57,8 +57,10 @@ elif [ -z "${CA_CERT}" ]; then
 fi
 
 # use localhost if no common name was provided
+GENERATE_MTLS_DOTENV_FILE=false
 if [ -z "${COMMON_NAME}" ]; then
     COMMON_NAME="localhost"
+    GENERATE_MTLS_DOTENV_FILE=true
     echo "Using common name: ${COMMON_NAME}"
     echo "This can be changed by passing a command line argument to the script:"
     echo "  $0 my-common-name"
@@ -74,8 +76,8 @@ mkdir -p mtls
 # wrapper function to run openssl command and handle result
 run_command() {
     set +e
-    
-    local cmd="$*"    
+
+    local cmd="$*"
     local operation=$2
     case "${operation}" in
         "genpkey") operation="generate private key" ;;
@@ -89,7 +91,7 @@ run_command() {
             echo -e "  \e[32m✔\e[0m remove certificate signing requests"
         else
             local asset=$(echo "$*" | awk '{
-                for (i=1; i<NF; i++) 
+                for (i=1; i<NF; i++)
                     if ($i == "-out") print $(i+1)
             }')
             echo -e "  \e[32m✔\e[0m ${operation}: \e[34m${asset}\e[0m"
@@ -155,3 +157,17 @@ run_command openssl x509 -req \
 run_command rm ./mtls/*.csr
 
 echo "MTLS setup complete"
+
+# write .env.mtls for running dal-mock locally against the Docker kits emulation
+if ${GENERATE_MTLS_DOTENV_FILE}; then
+    {
+        echo "KITS_CA_CERT=$(cat ./mtls/ca.crt | base64 | tr -d '\n')"
+        echo "KITS_INTERNAL_GATEWAY_URL=https://localhost:3101/extapi"
+        echo "KITS_INTERNAL_CONNECTION_CERT=$(cat ./mtls/client.crt | base64 | tr -d '\n')"
+        echo "KITS_INTERNAL_CONNECTION_KEY=$(cat ./mtls/client.key | base64 | tr -d '\n')"
+        echo "KITS_EXTERNAL_GATEWAY_URL=https://localhost:3101/extapi"
+        echo "KITS_EXTERNAL_CONNECTION_CERT=$(cat ./mtls/client.crt | base64 | tr -d '\n')"
+        echo "KITS_EXTERNAL_CONNECTION_KEY=$(cat ./mtls/client.key | base64 | tr -d '\n')"
+    } > ../.env.mtls
+    echo ".env.mtls written to project root"
+fi

--- a/scripts/setup-mtls.sh
+++ b/scripts/setup-mtls.sh
@@ -56,8 +56,9 @@ elif [ -z "${CA_CERT}" ]; then
     exit 1
 fi
 
-# use localhost if no common name was provided
 GENERATE_MTLS_DOTENV_FILE=false
+
+# use localhost if no common name was provided
 if [ -z "${COMMON_NAME}" ]; then
     COMMON_NAME="localhost"
     GENERATE_MTLS_DOTENV_FILE=true
@@ -132,11 +133,17 @@ run_command openssl genpkey \
 run_command openssl req -new \
     -key ./mtls/server.key -passin pass:server-password \
     -out ./mtls/server.csr -subj '/CN='"${COMMON_NAME}"
+
+# Write the SAN extension to a file rather than using -addext, which requires OpenSSL 1.1.1+
+# and is not supported on macOS's bundled LibreSSL.
+echo "subjectAltName=DNS:${COMMON_NAME}" > ./mtls/server.ext
+
 run_command openssl x509 -req \
     -in ./mtls/server.csr -out ./mtls/server.crt \
     -CA ${CA_CERT} -CAkey ${CA_KEY} -passin pass:ca-password \
     -CAcreateserial -CAserial ./mtls/ca.srl \
-    -days ${TEST_ASSET_TTL}
+    -days ${TEST_ASSET_TTL} \
+    -extfile ./mtls/server.ext
 
 # setup client assets
 run_command openssl genpkey \
@@ -154,7 +161,7 @@ run_command openssl x509 -req \
     -days ${TEST_ASSET_TTL}
 
 # tidy up - remove CSR files
-run_command rm ./mtls/*.csr
+run_command rm ./mtls/*.csr ./mtls/*.ext
 
 echo "MTLS setup complete"
 

--- a/setup-mtls.md
+++ b/setup-mtls.md
@@ -1,0 +1,91 @@
+# Setting up locally for KITS MTLS
+
+## Overview
+
+The mock server contains endpoints to proxy on to a real KITS implementation. This can be used, for example, to verify
+the schema, or just to invoke manually, in order to see what a payload response would look like, at development time.
+On a deployed environment, this will be configured to point to a real KITS endpoint, such as `upgrade`
+
+This isn't possible when running locally as there is no way to hit a deployed KITS server from your local machine.
+
+To work around this, you can deploy a second instance of the mock, setup with MTLS enabled. This mock can then be used
+to verify the proxy endpoints locally.
+
+```mermaid
+C4Context
+  title KITS proxy endpoint calling a mocked KTS
+
+  Boundary(mock, "Locally running mock (either npm or docker)", "") {
+    System_Ext(dal-mock, "FCP-DAL-MOCK", "Mock providing standard mock data, and a proxy endpoint")
+
+  }
+
+  Boundary(dal, "MTLS protected mock (docker)", "") {
+    System(dal-mock-mtls, "FCP-DAL-MOCK (MTLS)", "Mock simulating the MTLS authenticated KITS for proxy verification")
+  }
+
+
+  Rel(dal-mock, dal-mock-mtls, "REST")
+
+```
+
+## Running the proxied upstream
+
+Running the following script
+
+```shell
+./scripts/run-proxy-upstream-with-mtls-kits.sh
+```
+
+will:
+
+- Create a MTLS directory, with all the certificates needed
+- Start a docker container (`compose-mock-with-mtls.yml`), with a mock secured by MTLS
+
+You can then directly access the mock as follows
+
+> curl --cacert scripts/mtls/ca.crt --cert scripts/mtls/client.crt --key scripts/mtls/client.key https://localhost:3101/extapi/person/3010037/summary
+
+(Note that the certificate CN is set to localhost with this setup)
+
+## Configuring the main mock to use this secondary mock for it's proxied endpoint
+
+### Fully dockerised approach
+
+The simplest approach here is to run docker compose with both the mock and the downstream kits emulation version of
+the mock. To do this, run the following script:
+
+```shell
+./scripts/run-dal-downstream-and-mtls-kits-upstream.sh
+```
+
+This generates certificates/keys needed to support MTLS and then starts two docker containers
+
+- Standard DAL mock (dal-mock) containing
+  - Standard DAL endpoints
+    - /api
+    - /extapi
+  - Proxy Endpoint
+    - /proxy
+      - This uses MTLS to communicates with the KITS emulation docker image below
+- The MTLS secured KITS simulator (kits-emulation-mock), used as the upstream for the standard mock above
+
+You can the access the KITS-emulator via the DAL mock proxy as follows:
+
+> curl http://localhost:3100/proxy/internal/extapi/person/3010037/summary
+
+or
+
+> curl http://localhost:3100/proxy/external/extapi/person/3010037/summary
+
+### Running the mock locally against a docker KITS emulator
+
+If you want to start the DAL mock locally, without using docker, then you need to start the docker container as
+described in [Running the proxied upstream](#running-the-proxied-upstream).
+
+You then need to start the DAL mock locally, with the MTLS configuration in place (this will use the .env.mtls file
+generated, when the certificates were created when starting the upstream).
+
+```
+npm run dev-with-locally-proxied-kits
+```

--- a/setup-mtls.md
+++ b/setup-mtls.md
@@ -68,7 +68,7 @@ This generates certificates/keys needed to support MTLS and then starts two dock
   - Proxy Endpoint
     - /proxy
       - This uses MTLS to communicates with the KITS emulation docker image below
-- The MTLS secured KITS simulator (kits-emulation-mock), used as the upstream for the standard mock above
+- The MTLS secured KITS simulator (kits-proxied-upstream), used as the upstream for the standard mock above
 
 You can the access the KITS-emulator via the DAL mock proxy as follows:
 
@@ -89,3 +89,15 @@ generated, when the certificates were created when starting the upstream).
 ```
 npm run dev-with-locally-proxied-kits
 ```
+
+You can then access the service on port 3001 as follows
+
+> curl http://localhost:3001/proxy/external/extapi/person/3010037/summary
+
+### Accessing the mock proxy in CDP Dev environment
+
+It is not possible to directly access the deployed API, from your local machine. Instead, you need to access the
+API via the ephemeral gateway using a [developer API key](https://github.com/DEFRA/cdp-documentation/blob/main/how-to/developer-api-key.md)
+(valid for 24 hours). You can then access the proxy as follows
+
+> curl --header 'x-api-key: {API-KEY}' https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi/person/3010037/summary

--- a/src/config.js
+++ b/src/config.js
@@ -74,6 +74,73 @@ const config = convict({
     default: 3337243,
     env: 'KIT_EXT_PERSON_ID_OVERRIDE'
   },
+  // All KITS properties are optional, as KITS proxy is only accessible from a deployed environment
+  kitsProxy: {
+    internal: {
+      connectionCert: {
+        doc: 'Base64 encoded mTLS certificate for the KITS internal gateway connection',
+        format: String,
+        default: null,
+        sensitive: true,
+        nullable: true,
+        env: 'KITS_INTERNAL_CONNECTION_CERT'
+      },
+      connectionKey: {
+        doc: 'Base64 encoded mTLS key for the KITS internal gateway connection',
+        format: String,
+        default: null,
+        sensitive: true,
+        nullable: true,
+        env: 'KITS_INTERNAL_CONNECTION_KEY'
+      },
+      gatewayUrl: {
+        doc: 'KITS gateway internal URL',
+        format: String,
+        default: null,
+        nullable: true,
+        env: 'KITS_INTERNAL_GATEWAY_URL'
+      }
+    },
+    external: {
+      connectionCert: {
+        doc: 'Base64 encoded mTLS certificate for the KITS external gateway connection',
+        format: String,
+        default: null,
+        sensitive: true,
+        nullable: true,
+        env: 'KITS_EXTERNAL_CONNECTION_CERT'
+      },
+      connectionKey: {
+        doc: 'Base64 encoded mTLS key for the KITS external gateway connection',
+        format: String,
+        default: null,
+        sensitive: true,
+        nullable: true,
+        env: 'KITS_EXTERNAL_CONNECTION_KEY'
+      },
+      gatewayUrl: {
+        doc: 'KITS gateway external URL',
+        format: String,
+        default: null,
+        nullable: true,
+        env: 'KITS_EXTERNAL_GATEWAY_URL'
+      }
+    },
+    caCert: {
+      doc: 'Base64 encoded CA certificate for KITS mTLS connection',
+      format: String,
+      default: null,
+      sensitive: true,
+      nullable: true,
+      env: 'KITS_CA_CERT'
+    },
+    gatewayTimeoutMs: {
+      doc: 'KITS gateway timeout in milliseconds',
+      format: 'int',
+      default: 30000,
+      env: 'KITS_GATEWAY_TIMEOUT_MS'
+    }
+  },
   tls: {
     key: {
       doc: 'TLS private key',
@@ -116,6 +183,28 @@ if (config.get('tls.key') || config.get('tls.cert')) {
     cert: config.get('tls.cert') && decodeBase64Config(config.get('tls.cert'))
   }
   if (config.get('tls.ca')) config.decodedTLS.ca = decodeBase64Config(config.get('tls.ca'))
+}
+
+const ca = config.get('kitsProxy.caCert') && decodeBase64Config(config.get('kitsProxy.caCert'))
+config.decodedKitsMTLS = {
+  internal: {
+    cert:
+      config.get('kitsProxy.internal.connectionCert') &&
+      decodeBase64Config(config.get('kitsProxy.internal.connectionCert')),
+    key:
+      config.get('kitsProxy.internal.connectionKey') &&
+      decodeBase64Config(config.get('kitsProxy.internal.connectionKey')),
+    ca
+  },
+  external: {
+    cert:
+      config.get('kitsProxy.external.connectionCert') &&
+      decodeBase64Config(config.get('kitsProxy.external.connectionCert')),
+    key:
+      config.get('kitsProxy.external.connectionKey') &&
+      decodeBase64Config(config.get('kitsProxy.external.connectionKey')),
+    ca
+  }
 }
 
 export { config }

--- a/src/config.js
+++ b/src/config.js
@@ -126,6 +126,13 @@ const config = convict({
         env: 'KITS_EXTERNAL_GATEWAY_URL'
       }
     },
+    enabled: {
+      doc: 'Should the KITS proxy be enabled',
+      format: Boolean,
+      nullable: true,
+      default: !!process.env.KITS_INTERNAL_CONNECTION_CERT,
+      env: 'KITS_PROXY_ENABLED'
+    },
     caCert: {
       doc: 'Base64 encoded CA certificate for KITS mTLS connection',
       format: String,
@@ -185,7 +192,6 @@ if (config.get('tls.key') || config.get('tls.cert')) {
   if (config.get('tls.ca')) config.decodedTLS.ca = decodeBase64Config(config.get('tls.ca'))
 }
 
-const ca = config.get('kitsProxy.caCert') && decodeBase64Config(config.get('kitsProxy.caCert'))
 config.decodedKitsMTLS = {
   internal: {
     cert:
@@ -193,8 +199,7 @@ config.decodedKitsMTLS = {
       decodeBase64Config(config.get('kitsProxy.internal.connectionCert')),
     key:
       config.get('kitsProxy.internal.connectionKey') &&
-      decodeBase64Config(config.get('kitsProxy.internal.connectionKey')),
-    ca
+      decodeBase64Config(config.get('kitsProxy.internal.connectionKey'))
   },
   external: {
     cert:
@@ -202,9 +207,14 @@ config.decodedKitsMTLS = {
       decodeBase64Config(config.get('kitsProxy.external.connectionCert')),
     key:
       config.get('kitsProxy.external.connectionKey') &&
-      decodeBase64Config(config.get('kitsProxy.external.connectionKey')),
-    ca
+      decodeBase64Config(config.get('kitsProxy.external.connectionKey'))
   }
+}
+
+const ca = config.get('kitsProxy.caCert') && decodeBase64Config(config.get('kitsProxy.caCert'))
+if (ca) {
+  config.decodedKitsMTLS.internal.ca = ca
+  config.decodedKitsMTLS.external.ca = ca
 }
 
 export { config }

--- a/src/routes/proxy/kits-proxy.router.js
+++ b/src/routes/proxy/kits-proxy.router.js
@@ -5,11 +5,17 @@ import tls from 'node:tls'
 
 const logger = createLogger()
 
-const ALLOWED_HEADERS = new Set(['email'])
+const ALLOWED_REQUEST_HEADERS = new Set(['email', 'content-type', 'accept'])
+const ALLOWED_RESPONSE_HEADERS = new Set(['content-type'])
 
-const extractHeaders = (headers) =>
+const extractRequestHeaders = (headers) =>
   Object.fromEntries(
-    Object.entries(headers).filter(([key]) => ALLOWED_HEADERS.has(key.toLowerCase()))
+    Object.entries(headers).filter(([key]) => ALLOWED_REQUEST_HEADERS.has(key.toLowerCase()))
+  )
+
+const extractResponseHeaders = (headers) =>
+  Object.fromEntries(
+    Object.entries(headers).filter(([key]) => ALLOWED_RESPONSE_HEADERS.has(key.toLowerCase()))
   )
 
 const mtlsDispatcher = (mtlsConfig, baseUrl) => {
@@ -50,16 +56,27 @@ const proxyRoute = (routePath, baseUrl, mtlsConfig) => {
       const targetUrl = `${baseUrl}/${forwardedPath}${request.url.search}`
 
       logger.debug(`Proxying ${request.method.toUpperCase()} ${targetUrl}`)
-      const upstreamResponse = await fetch11(targetUrl, {
-        method: request.method,
-        headers: extractHeaders(request.headers),
-        body: request.payload ?? undefined,
-        dispatcher,
-        signal: AbortSignal.timeout(config.get('kitsProxy.gatewayTimeoutMs'))
-      })
-      const responseBody = await upstreamResponse.arrayBuffer()
-
-      return h.response(Buffer.from(responseBody)).code(upstreamResponse.status)
+      try {
+        const upstreamResponse = await fetch11(targetUrl, {
+          method: request.method,
+          headers: extractRequestHeaders(request.headers),
+          body: request.payload ?? undefined,
+          dispatcher,
+          signal: AbortSignal.timeout(config.get('kitsProxy.gatewayTimeoutMs'))
+        })
+        const responseBody = await upstreamResponse.arrayBuffer()
+        const responseHeaders = extractResponseHeaders(
+          Object.fromEntries(upstreamResponse.headers.entries())
+        )
+        const response = h.response(Buffer.from(responseBody)).code(upstreamResponse.status)
+        for (const [name, value] of Object.entries(responseHeaders)) {
+          response.header(name, value)
+        }
+        return response
+      } catch (error) {
+        logger.error(JSON.stringify(error))
+        throw error
+      }
     }
   }
 }

--- a/src/routes/proxy/kits-proxy.router.js
+++ b/src/routes/proxy/kits-proxy.router.js
@@ -1,0 +1,84 @@
+import { fetch as fetch11, Agent } from 'undici'
+import { config } from '../../config.js'
+
+const HOP_BY_HOP_HEADERS_FOR_EXCLUSION = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailers',
+  'transfer-encoding',
+  'upgrade',
+  'host'
+])
+
+// Certain headers should not be forwarded, when proxying (these headers are specific to this `hop`
+// in the request chain.  Ensure we don't forward them on.
+// TODO Might be safer coming the other way... What headers, if any, SHOULD be forwarded on?
+const filerOutHopByHopHeaders = (headers) =>
+  Object.fromEntries(
+    Object.entries(headers).filter(([key]) => !HOP_BY_HOP_HEADERS_FOR_EXCLUSION.has(key))
+  )
+
+const mtlsDispatcherAgent = (mtlsConfig) => {
+  return new Agent({
+    connect: {
+      ca: mtlsConfig.ca || undefined,
+      cert: mtlsConfig.cert || undefined,
+      key: mtlsConfig.key || undefined
+    }
+  })
+}
+
+const proxyRoute = (routePath, baseUrl, mtlsConfig) => ({
+  method: '*',
+  path: routePath,
+  options: {
+    auth: false,
+    payload: { output: 'data', parse: false }
+  },
+  handler: async (request, h) => {
+    const forwardedPath = request.params.path ?? ''
+    const targetUrl = `${baseUrl}/${forwardedPath}${request.url.search}`
+
+    const upstreamResponse = await fetch11(targetUrl, {
+      method: request.method,
+      headers: filerOutHopByHopHeaders(request.headers),
+      body: request.payload ?? undefined,
+      dispatcher: mtlsDispatcherAgent(mtlsConfig),
+      signal: AbortSignal.timeout(config.get('kitsProxy.gatewayTimeoutMs'))
+    })
+
+    const responseBody = await upstreamResponse.arrayBuffer()
+    const responseHeaders = filerOutHopByHopHeaders(
+      Object.fromEntries(upstreamResponse.headers.entries())
+    )
+
+    const response = h.response(Buffer.from(responseBody)).code(upstreamResponse.status)
+    for (const [name, value] of Object.entries(responseHeaders)) {
+      response.header(name, value)
+    }
+    return response
+  }
+})
+
+export const router = {
+  plugin: {
+    name: 'kits-proxy-router',
+    register: (server, _) => {
+      server.route([
+        proxyRoute(
+          '/internal/extapi/{path*}',
+          config.get('kitsProxy.internal.gatewayUrl'),
+          config.decodedKitsMTLS.internal
+        ),
+        proxyRoute(
+          '/external/extapi/{path*}',
+          config.get('kitsProxy.external.gatewayUrl'),
+          config.decodedKitsMTLS.external
+        )
+      ])
+    }
+  }
+}

--- a/src/routes/proxy/kits-proxy.router.js
+++ b/src/routes/proxy/kits-proxy.router.js
@@ -72,6 +72,10 @@ const proxyRoute = (routePath, baseUrl, mtlsConfig) => {
         for (const [name, value] of Object.entries(responseHeaders)) {
           response.header(name, value)
         }
+        // The body has already been decoded by undici (arrayBuffer auto-decompresses).
+        // Setting identity here prevents the CDP ingress from re-gzipping the response,
+        // which produces invalid gzip for certain upstream error payloads.
+        response.header('content-encoding', 'identity')
         return response
       } catch (error) {
         logger.error(JSON.stringify(error))

--- a/src/routes/proxy/kits-proxy.router.js
+++ b/src/routes/proxy/kits-proxy.router.js
@@ -1,67 +1,68 @@
-import { fetch as fetch11, Agent } from 'undici'
+import { fetch as fetch11, EnvHttpProxyAgent } from 'undici'
 import { config } from '../../config.js'
+import { createLogger } from '../../common/helpers/logging/logger.js'
+import tls from 'node:tls'
 
-const HOP_BY_HOP_HEADERS_FOR_EXCLUSION = new Set([
-  'connection',
-  'keep-alive',
-  'proxy-authenticate',
-  'proxy-authorization',
-  'te',
-  'trailers',
-  'transfer-encoding',
-  'upgrade',
-  'host'
-])
+const logger = createLogger()
 
-// Certain headers should not be forwarded, when proxying (these headers are specific to this `hop`
-// in the request chain.  Ensure we don't forward them on.
-// TODO Might be safer coming the other way... What headers, if any, SHOULD be forwarded on?
-const filerOutHopByHopHeaders = (headers) =>
+const ALLOWED_HEADERS = new Set(['email'])
+
+const extractHeaders = (headers) =>
   Object.fromEntries(
-    Object.entries(headers).filter(([key]) => !HOP_BY_HOP_HEADERS_FOR_EXCLUSION.has(key))
+    Object.entries(headers).filter(([key]) => ALLOWED_HEADERS.has(key.toLowerCase()))
   )
 
-const mtlsDispatcherAgent = (mtlsConfig) => {
-  return new Agent({
-    connect: {
-      ca: mtlsConfig.ca || undefined,
-      cert: mtlsConfig.cert || undefined,
-      key: mtlsConfig.key || undefined
-    }
+const mtlsDispatcher = (mtlsConfig, baseUrl) => {
+  const { hostname } = new URL(baseUrl)
+  const connectOptions = {
+    cert: mtlsConfig.cert,
+    key: mtlsConfig.key,
+    ...(mtlsConfig.ca && { ca: mtlsConfig.ca }),
+    servername: hostname
+  }
+
+  // EnvHttpProxyAgent handles two distinct connection paths:
+  // - Deployed (CDP) environments route traffic through a SQUID proxy, so traffic is routed
+  //   via a CONNECT tunnel. undici applies `requestTls` to the inner TLS connection inside that tunnel.
+  // - Local Docker has no proxy, so undici makes a direct TLS connection and applies `connect` instead.
+  //   Without `connect`, the self-signed CA is not trusted and the handshake fails with SELF_SIGNED_CERT_IN_CHAIN.
+  return new EnvHttpProxyAgent({
+    connect: connectOptions,
+    requestTls: { servername: hostname, secureContext: tls.createSecureContext(connectOptions) }
   })
 }
 
-const proxyRoute = (routePath, baseUrl, mtlsConfig) => ({
-  method: '*',
-  path: routePath,
-  options: {
-    auth: false,
-    payload: { output: 'data', parse: false }
-  },
-  handler: async (request, h) => {
-    const forwardedPath = request.params.path ?? ''
-    const targetUrl = `${baseUrl}/${forwardedPath}${request.url.search}`
-
-    const upstreamResponse = await fetch11(targetUrl, {
-      method: request.method,
-      headers: filerOutHopByHopHeaders(request.headers),
-      body: request.payload ?? undefined,
-      dispatcher: mtlsDispatcherAgent(mtlsConfig),
-      signal: AbortSignal.timeout(config.get('kitsProxy.gatewayTimeoutMs'))
-    })
-
-    const responseBody = await upstreamResponse.arrayBuffer()
-    const responseHeaders = filerOutHopByHopHeaders(
-      Object.fromEntries(upstreamResponse.headers.entries())
-    )
-
-    const response = h.response(Buffer.from(responseBody)).code(upstreamResponse.status)
-    for (const [name, value] of Object.entries(responseHeaders)) {
-      response.header(name, value)
-    }
-    return response
+const proxyRoute = (routePath, baseUrl, mtlsConfig) => {
+  if (!mtlsConfig.cert || !mtlsConfig.key) {
+    throw new Error(`mTLS cert/key not configured for route ${routePath}`)
   }
-})
+  const dispatcher = mtlsDispatcher(mtlsConfig, baseUrl)
+
+  return {
+    method: '*',
+    path: routePath,
+    options: {
+      auth: false,
+      payload: { output: 'data', parse: false }
+    },
+    handler: async (request, h) => {
+      const forwardedPath = request.params.path ?? ''
+      const targetUrl = `${baseUrl}/${forwardedPath}${request.url.search}`
+
+      logger.debug(`Proxying ${request.method.toUpperCase()} ${targetUrl}`)
+      const upstreamResponse = await fetch11(targetUrl, {
+        method: request.method,
+        headers: extractHeaders(request.headers),
+        body: request.payload ?? undefined,
+        dispatcher,
+        signal: AbortSignal.timeout(config.get('kitsProxy.gatewayTimeoutMs'))
+      })
+      const responseBody = await upstreamResponse.arrayBuffer()
+
+      return h.response(Buffer.from(responseBody)).code(upstreamResponse.status)
+    }
+  }
+}
 
 export const router = {
   plugin: {

--- a/src/routes/proxy/kits-proxy.router.js
+++ b/src/routes/proxy/kits-proxy.router.js
@@ -72,9 +72,10 @@ const proxyRoute = (routePath, baseUrl, mtlsConfig) => {
         for (const [name, value] of Object.entries(responseHeaders)) {
           response.header(name, value)
         }
-        // The body has already been decoded by undici (arrayBuffer auto-decompresses).
-        // Setting identity here prevents the CDP ingress from re-gzipping the response,
-        // which produces invalid gzip for certain upstream error payloads.
+
+        // Any content encoding applied by the upstream is lost when we create an ArrayBuffer from the
+        // upstream response body, so using the upstream's content-encoding would be incorrect here.
+        // Make it clear to any downstream caller that the body is not encoded
         response.header('content-encoding', 'identity')
         return response
       } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ import { requestTracing } from './common/helpers/request-tracing.js'
 import { config } from './config.js'
 import { router as hitachiRouter } from './routes/hitachi/payments.js'
 import { router as kitsRouter } from './plugins/kits-v1-router.js'
+import { router as kitsProxyRouter } from './routes/proxy/kits-proxy.router.js'
 import { health } from './plugins/health.js'
 import { schemata } from './plugins/schemata.js'
 
@@ -50,6 +51,7 @@ export const startServer = async (listener) => {
     await server.register([requestLogger, requestTracing, pulse, inert, health, schemata])
     await server.register(hitachiRouter, { routes: { prefix: '/api' } })
     await server.register(kitsRouter, { routes: { prefix: '/extapi' } })
+    await server.register(kitsProxyRouter, { routes: { prefix: '/proxy' } })
 
     // emulate upstream error responses
     server.ext('onPreResponse', emulateUpstreamErrors)

--- a/src/server.js
+++ b/src/server.js
@@ -51,7 +51,9 @@ export const startServer = async (listener) => {
     await server.register([requestLogger, requestTracing, pulse, inert, health, schemata])
     await server.register(hitachiRouter, { routes: { prefix: '/api' } })
     await server.register(kitsRouter, { routes: { prefix: '/extapi' } })
-    await server.register(kitsProxyRouter, { routes: { prefix: '/proxy' } })
+    if (config.get('kitsProxy.enabled')) {
+      await server.register(kitsProxyRouter, { routes: { prefix: '/proxy' } })
+    }
 
     // emulate upstream error responses
     server.ext('onPreResponse', emulateUpstreamErrors)

--- a/test/contract/README.md
+++ b/test/contract/README.md
@@ -12,6 +12,9 @@ These same schemata can then be used to check the mock to ensure proper conforma
 
 ## Checking a KITS target
 
+Before running the script, you need to [create a developer API key](https://github.com/DEFRA/cdp-documentation/blob/main/how-to/developer-api-key.md).
+This key will be valid for 24 hours.
+
 Run the automated checks using the convenience script, get more by running:
 
 ```shell
@@ -21,10 +24,8 @@ test/contract/check-schema.sh help
 ...but basically something like the following:
 
 ```shell
-export KITS_KEY=path/to/upgrade.key
-export KITS_CERT=path/to/upgrade.cert
-export CDP_PROXY=https://<user>:<pass>@proxy.dev.cdp-int.defra.cloud
-export KITS_URL=https://chs-upgrade-api.ruraldev.org.uk:8446/extapi
+export CDP_API_KEY=[KEY GENERATED ABOVE]
+export KITS_URL=https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi
 test/contract/check-schema.sh person
 ```
 

--- a/test/contract/README.md
+++ b/test/contract/README.md
@@ -32,6 +32,8 @@ This will perform a bunch of tests to check the specified schema (in this case t
 
 > NOTE: Only the KITS `upgrade` service is currently considered for testing, but other environments could also be checked by changing the target and providing the according mTLS details.
 
+> NOTE: The script uses [yq](https://github.com/mikefarah/yq) - ensure you have it installed, as it is not a project-level installation
+
 ## Checking local mock
 
 There is now a `/schemata` route that serves the OAS definitions of the mock, so checking mock endpoints match, is as simple as calling an NPM script with the target URL:

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -23,10 +23,8 @@ usage() {
   echo "  h  | help                - show this help message"
   echo
   echo "NOTE: additionally the following environment variables must be set:"
-  echo "  KITS_KEY  - KITS client key file (path relative to project root)"
-  echo "  KITS_CERT - KITS client certificate file (path relative to project root)"
-  echo "  CDP_PROXY - the URL of the CDP HTTPS proxy to use"
-  echo "  KITS_URL  - the URL of the KITS API to use"
+  echo "  CDP_API_KEY - CDP Platform developer API key "
+  echo "  KITS_URL  - the URL of the KITS API to use (this should be the DAL Mock proxy endpoint, via the ephemeral endpoint)"
   echo "or..."
   echo "  HITACHI_CLIENT_SECRET - the client secret for token generation"
 }
@@ -94,44 +92,20 @@ yq eval -o=json "${mutations}" ${rootDir}/src/routes/${schema}-schema.oas.yml \
 
 # run schemathesis tests
 if ${kits} ; then # KITS gateway
-  echo "ERROR: Temporarily failing KITS test runs as not possible until the following"
-  echo "work has been completed:"
-  echo "  - mock backdoor to KITS https://eaflood.atlassian.net/browse/FCPDAL-253"
-  exit 1
-
-  # resolve KITS_KEY
-  if [ -f "${KITS_KEY}" ]; then
-    KITS_KEY="$(cd "$(dirname "${KITS_KEY}")" && pwd)/$(basename "${KITS_KEY}")"
-  elif [ -f "${rootDir}/${KITS_KEY}" ]; then
-    KITS_KEY="${rootDir}/${KITS_KEY}"
-  else
-    echo "KITS_KEY file not found: ${KITS_KEY} or ${rootDir}/${KITS_KEY}"
+  if [ -z "${CDP_API_KEY}" ]; then
+    echo "ERROR: CDP_API_KEY environment variable is not set" 1>&2
     usage
     exit 1
   fi
-  # resolve KITS_CERT
-  if [ -f "${KITS_CERT}" ]; then
-    KITS_CERT="$(cd "$(dirname "${KITS_CERT}")" && pwd)/$(basename "${KITS_CERT}")"
-  elif [ -f "${rootDir}/${KITS_CERT}" ]; then
-    KITS_CERT="${rootDir}/${KITS_CERT}"
-  else
-    echo "KITS_CERT file not found: ${KITS_CERT} or ${rootDir}/${KITS_CERT}"
-    usage
-    exit 1
-  fi
-
   docker run --rm --network=host --pull always \
     -v ${baseDir}/tmp:/tmp \
-    -v ${KITS_KEY}:/kits.key \
-    -v ${KITS_CERT}:/kits.crt \
     schemathesis/schemathesis:stable \
       run /tmp/schema.json \
         --header "email: ${TEST_USER_EMAIL:-testuser01@defra.gov.uk}" \
+        --header "x-api-key: ${CDP_API_KEY}" \
         --exclude-checks=unsupported_method,not_a_server_error \
-        --request-cert /kits.crt \
-        --request-cert-key /kits.key \
         --report-vcr-path /tmp/vcr.yaml \
-        --url "${KITS_URL:-https://chs-upgrade-api.ruraldev.org.uk:8446/extapi}"
+        --url "${KITS_URL:-https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi}"
 
 else # hitachi
   if [ -z "${HITACHI_CLIENT_SECRET}" ]; then
@@ -148,7 +122,7 @@ else # hitachi
     --data "client_secret=${HITACHI_CLIENT_SECRET}" \
     --data resource=https://orgcf202fa2.operations.eu.dynamics.com \
     | jq -r '.access_token' )
-  
+
   # check the token looks good
   if [ "${HITACHI_TOKEN}" = "null" ]; then
     echo "ERROR: HITACHI_TOKEN was not generated correctly, check the secret is correct" 1>&2

--- a/test/integration/mtls-setup.test.js
+++ b/test/integration/mtls-setup.test.js
@@ -7,11 +7,13 @@ import { fileURLToPath } from 'node:url'
 describe('mTLS setup', () => {
   const PROCESS_ENV = process.env
   const testDir = dirname(fileURLToPath(import.meta.url))
+  const projectRoot = join(testDir, '../..')
+  const mtlsDir = join(projectRoot, 'scripts', 'mtls')
   let ca, hapi
   const options = { hostname: 'localhost', port: 3443, path: '/health', rejectUnauthorized: true }
 
   const readAsset = async (asset) => {
-    const value = await readFile(join(testDir, 'mtls', asset), 'utf8')
+    const value = await readFile(join(mtlsDir, asset), 'utf8')
     return Buffer.from(value).toString('base64')
   }
 
@@ -37,10 +39,10 @@ describe('mTLS setup', () => {
 
   beforeAll(async () => {
     // const result = // Uncomment for debugging
-    execSync('bash setup-mtls.sh', { cwd: testDir })
+    execSync('bash scripts/setup-mtls.sh', { cwd: projectRoot })
     // console.log(result.toString()) // Uncomment for debugging
 
-    ca = await readFile(join(testDir, 'mtls', 'ca.crt'), 'utf8')
+    ca = await readFile(join(mtlsDir, 'ca.crt'), 'utf8')
     options.ca = ca
 
     process.env = { ...PROCESS_ENV }
@@ -57,7 +59,7 @@ describe('mTLS setup', () => {
   afterAll(async () => {
     await hapi.stop()
     process.env = PROCESS_ENV
-    await rm(join(testDir, 'mtls'), { recursive: true, force: true })
+    await rm(mtlsDir, { recursive: true, force: true })
   })
 
   it('should start HTTPS server with mTLS enabled', async () => {
@@ -72,8 +74,8 @@ describe('mTLS setup', () => {
   })
 
   it('should accept connections with valid client certificate', async () => {
-    const key = await readFile(join(testDir, 'mtls', 'client.key'), 'utf8')
-    const cert = await readFile(join(testDir, 'mtls', 'client.crt'), 'utf8')
+    const key = await readFile(join(mtlsDir, 'client.key'), 'utf8')
+    const cert = await readFile(join(mtlsDir, 'client.crt'), 'utf8')
 
     expect(await makeRequest({ ...options, key, cert })).toEqual({
       statusCode: 200,

--- a/test/integration/routes/proxy/kits-proxy.router.test.js
+++ b/test/integration/routes/proxy/kits-proxy.router.test.js
@@ -1,0 +1,194 @@
+import { jest, expect, describe, beforeAll, afterAll, beforeEach, test } from '@jest/globals'
+import Hapi from '@hapi/hapi'
+
+const mockFetch = jest.fn()
+
+jest.unstable_mockModule('undici', () => ({
+  fetch: mockFetch,
+  Agent: class {
+    constructor() {}
+  }
+}))
+
+const INTERNAL_URL = 'http://internal-gateway.test'
+const EXTERNAL_URL = 'http://external-gateway.test'
+
+jest.unstable_mockModule('../../../../src/config.js', () => ({
+  config: {
+    get: (key) =>
+      ({
+        'kitsProxy.internal.gatewayUrl': INTERNAL_URL,
+        'kitsProxy.external.gatewayUrl': EXTERNAL_URL,
+        'kitsProxy.gatewayTimeoutMs': 5000
+      })[key],
+    decodedKitsMTLS: {
+      internal: {},
+      external: {}
+    }
+  }
+}))
+
+const mockUpstreamResponse = ({ body = {}, status = 200, headers = {} } = {}) => {
+  const encoded = new TextEncoder().encode(JSON.stringify(body))
+  mockFetch.mockResolvedValueOnce({
+    status,
+    arrayBuffer: async () => encoded.buffer,
+    headers: new Headers({ 'content-type': 'application/json', ...headers })
+  })
+}
+
+/**
+ * This is a bit of  a hybrid test.  The proxy route is tested by starting a real Hapi server with
+ * the upstream fetch mocked.  This validates routing, header filtering, and status code
+ * pass-through without a live upstream.
+ */
+describe('KITS Proxy router', () => {
+  let server
+
+  beforeAll(async () => {
+    const { router } = await import('../../../../src/routes/proxy/kits-proxy.router.js')
+    server = Hapi.server()
+    await server.register(router)
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server?.stop({ timeout: 0 })
+  })
+
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  describe('/internal/extapi', () => {
+    test('forwards GET to the internal gateway URL', async () => {
+      mockUpstreamResponse({ body: { _data: { id: 123 } } })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/person/123/summary'
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${INTERNAL_URL}/person/123/summary`,
+        expect.objectContaining({ method: 'get' })
+      )
+    })
+
+    test('forwards query string to upstream', async () => {
+      mockUpstreamResponse({ body: { notifications: [] } })
+
+      await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/notifications?personId=123&organisationId=456'
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${INTERNAL_URL}/notifications?personId=123&organisationId=456`,
+        expect.anything()
+      )
+    })
+
+    test('forwards POST with body to upstream', async () => {
+      mockUpstreamResponse({ body: { _data: [] } })
+
+      await server.inject({
+        method: 'POST',
+        url: '/internal/extapi/person/search',
+        headers: { 'content-type': 'application/json' },
+        payload: { primarySearchPhrase: '1111111100', searchFieldType: 'CUSTOMER_REFERENCE' }
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${INTERNAL_URL}/person/search`,
+        expect.objectContaining({ method: 'post' })
+      )
+    })
+
+    test('strips hop-by-hop headers before forwarding', async () => {
+      mockUpstreamResponse()
+
+      await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/person/123/summary',
+        headers: {
+          'x-custom-header': 'keep-me',
+          connection: 'close',
+          'transfer-encoding': 'chunked',
+          host: 'original-host'
+        }
+      })
+
+      const [, { headers }] = mockFetch.mock.calls[0]
+      expect(headers['x-custom-header']).toBe('keep-me')
+      expect(headers['connection']).toBeUndefined()
+      expect(headers['transfer-encoding']).toBeUndefined()
+      expect(headers['host']).toBeUndefined()
+    })
+
+    test('returns upstream status code to caller', async () => {
+      mockUpstreamResponse({ status: 404 })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/person/99999/summary'
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    test('returns upstream 5xx to caller', async () => {
+      mockUpstreamResponse({ status: 503 })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/organisation/123'
+      })
+
+      expect(response.statusCode).toBe(503)
+    })
+  })
+
+  describe('/external/extapi', () => {
+    test('forwards GET to the external gateway URL', async () => {
+      mockUpstreamResponse({ body: { _data: { id: 123 } } })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/external/extapi/person/123/summary'
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${EXTERNAL_URL}/person/123/summary`,
+        expect.objectContaining({ method: 'get' })
+      )
+    })
+
+    test('forwards query string to upstream', async () => {
+      mockUpstreamResponse()
+
+      await server.inject({
+        method: 'GET',
+        url: '/external/extapi/notifications?personId=123&organisationId=456'
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${EXTERNAL_URL}/notifications?personId=123&organisationId=456`,
+        expect.anything()
+      )
+    })
+
+    test('returns upstream error codes to caller', async () => {
+      mockUpstreamResponse({ status: 403 })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/external/extapi/person/123/summary'
+      })
+
+      expect(response.statusCode).toBe(403)
+    })
+  })
+})

--- a/test/integration/routes/proxy/kits-proxy.router.test.js
+++ b/test/integration/routes/proxy/kits-proxy.router.test.js
@@ -5,13 +5,26 @@ const mockFetch = jest.fn()
 
 jest.unstable_mockModule('undici', () => ({
   fetch: mockFetch,
-  Agent: class {
+  EnvHttpProxyAgent: class {
     constructor() {}
   }
 }))
 
+jest.unstable_mockModule('node:tls', () => ({
+  default: { createSecureContext: jest.fn().mockReturnValue({}) }
+}))
+
 const INTERNAL_URL = 'http://internal-gateway.test'
 const EXTERNAL_URL = 'http://external-gateway.test'
+
+jest.unstable_mockModule('../../../../src/common/helpers/logging/logger.js', () => ({
+  createLogger: () => ({ debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+}))
+
+let mockMTLSConfig = {
+  internal: { cert: 'internal-cert', key: 'internal-key' },
+  external: { cert: 'external-cert', key: 'external-key' }
+}
 
 jest.unstable_mockModule('../../../../src/config.js', () => ({
   config: {
@@ -21,9 +34,8 @@ jest.unstable_mockModule('../../../../src/config.js', () => ({
         'kitsProxy.external.gatewayUrl': EXTERNAL_URL,
         'kitsProxy.gatewayTimeoutMs': 5000
       })[key],
-    decodedKitsMTLS: {
-      internal: {},
-      external: {}
+    get decodedKitsMTLS() {
+      return mockMTLSConfig
     }
   }
 }))
@@ -38,8 +50,8 @@ const mockUpstreamResponse = ({ body = {}, status = 200, headers = {} } = {}) =>
 }
 
 /**
- * This is a bit of  a hybrid test.  The proxy route is tested by starting a real Hapi server with
- * the upstream fetch mocked.  This validates routing, header filtering, and status code
+ * This is a bit of a hybrid integration/unit test.  The proxy route is tested by starting a real
+ * Hapi server with, but the upstream is mocked.  This validates routing, header filtering, and status code
  * pass-through without a live upstream.
  */
 describe('KITS Proxy router', () => {
@@ -75,7 +87,26 @@ describe('KITS Proxy router', () => {
         expect.objectContaining({ method: 'get' })
       )
     })
+  })
 
+  describe('/external/extapi', () => {
+    test('forwards GET to the external gateway URL', async () => {
+      mockUpstreamResponse({ body: { _data: { id: 123 } } })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/external/extapi/person/123/summary'
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${EXTERNAL_URL}/person/123/summary`,
+        expect.objectContaining({ method: 'get' })
+      )
+    })
+  })
+
+  describe('Non route specific behaviour', () => {
     test('forwards query string to upstream', async () => {
       mockUpstreamResponse({ body: { notifications: [] } })
 
@@ -106,7 +137,7 @@ describe('KITS Proxy router', () => {
       )
     })
 
-    test('strips hop-by-hop headers before forwarding', async () => {
+    test('forwards on email header', async () => {
       mockUpstreamResponse()
 
       await server.inject({
@@ -116,12 +147,14 @@ describe('KITS Proxy router', () => {
           'x-custom-header': 'keep-me',
           connection: 'close',
           'transfer-encoding': 'chunked',
+          email: 'email@example.com',
           host: 'original-host'
         }
       })
 
       const [, { headers }] = mockFetch.mock.calls[0]
-      expect(headers['x-custom-header']).toBe('keep-me')
+      expect(headers['email']).toBe('email@example.com')
+      expect(headers['x-custom-header']).toBeUndefined()
       expect(headers['connection']).toBeUndefined()
       expect(headers['transfer-encoding']).toBeUndefined()
       expect(headers['host']).toBeUndefined()
@@ -148,23 +181,6 @@ describe('KITS Proxy router', () => {
 
       expect(response.statusCode).toBe(503)
     })
-  })
-
-  describe('/external/extapi', () => {
-    test('forwards GET to the external gateway URL', async () => {
-      mockUpstreamResponse({ body: { _data: { id: 123 } } })
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/external/extapi/person/123/summary'
-      })
-
-      expect(response.statusCode).toBe(200)
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${EXTERNAL_URL}/person/123/summary`,
-        expect.objectContaining({ method: 'get' })
-      )
-    })
 
     test('forwards query string to upstream', async () => {
       mockUpstreamResponse()
@@ -189,6 +205,55 @@ describe('KITS Proxy router', () => {
       })
 
       expect(response.statusCode).toBe(403)
+    })
+
+    test('uses empty string for path when no path segment is provided', async () => {
+      mockUpstreamResponse()
+
+      await server.inject({ method: 'GET', url: '/internal/extapi' })
+
+      expect(mockFetch).toHaveBeenCalledWith(`${INTERNAL_URL}/`, expect.anything())
+    })
+  })
+
+  describe('mTLS configuration validation', () => {
+    let router
+
+    beforeAll(async () => {
+      ;({ router } = await import('../../../../src/routes/proxy/kits-proxy.router.js'))
+    })
+
+    beforeEach(() => {
+      mockMTLSConfig = {
+        internal: { cert: 'internal-cert', key: 'internal-key' },
+        external: { cert: 'external-cert', key: 'external-key' }
+      }
+    })
+
+    test('throws on registration when cert is missing', async () => {
+      mockMTLSConfig.internal = { key: 'internal-key' }
+      await expect(Hapi.server().register(router)).rejects.toThrow(
+        'mTLS cert/key not configured for route /internal/extapi/{path*}'
+      )
+    })
+
+    test('throws on registration when key is missing', async () => {
+      mockMTLSConfig.internal = { cert: 'internal-cert' }
+      await expect(Hapi.server().register(router)).rejects.toThrow(
+        'mTLS cert/key not configured for route /internal/extapi/{path*}'
+      )
+    })
+
+    test('includes ca in secure context when provided', async () => {
+      const { default: tls } = await import('node:tls')
+      tls.createSecureContext.mockClear()
+
+      mockMTLSConfig.internal.ca = 'ca-cert'
+      await Hapi.server().register(router)
+
+      expect(tls.createSecureContext).toHaveBeenCalledWith(
+        expect.objectContaining({ ca: 'ca-cert' })
+      )
     })
   })
 })

--- a/test/integration/routes/proxy/kits-proxy.router.test.js
+++ b/test/integration/routes/proxy/kits-proxy.router.test.js
@@ -45,7 +45,7 @@ const mockUpstreamResponse = ({ body = {}, status = 200, headers = {} } = {}) =>
   mockFetch.mockResolvedValueOnce({
     status,
     arrayBuffer: async () => encoded.buffer,
-    headers: new Headers({ 'content-type': 'application/json', ...headers })
+    headers: new Headers({ 'Content-Type': 'application/json', ...headers })
   })
 }
 
@@ -137,27 +137,51 @@ describe('KITS Proxy router', () => {
       )
     })
 
-    test('forwards on email header', async () => {
+    test('forwards only allowed request headers upstream', async () => {
       mockUpstreamResponse()
 
       await server.inject({
         method: 'GET',
         url: '/internal/extapi/person/123/summary',
         headers: {
-          'x-custom-header': 'keep-me',
+          email: 'email@example.com',
+          'content-type': 'application/json',
+          accept: 'application/json',
+          'x-custom-header': 'should-be-filtered',
           connection: 'close',
           'transfer-encoding': 'chunked',
-          email: 'email@example.com',
           host: 'original-host'
         }
       })
 
       const [, { headers }] = mockFetch.mock.calls[0]
       expect(headers['email']).toBe('email@example.com')
+      expect(headers['content-type']).toBe('application/json')
+      expect(headers['accept']).toBe('application/json')
       expect(headers['x-custom-header']).toBeUndefined()
       expect(headers['connection']).toBeUndefined()
       expect(headers['transfer-encoding']).toBeUndefined()
       expect(headers['host']).toBeUndefined()
+    })
+
+    test('forwards only allowed response headers to caller', async () => {
+      mockUpstreamResponse({
+        headers: {
+          'cache-control': 'no-cache',
+          'x-custom-header': 'should-be-filtered',
+          'set-cookie': 'session=abc'
+        }
+      })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/person/123/summary'
+      })
+
+      expect(response.headers['content-type']).toContain('application/json')
+      expect(response.headers['cache-control']).toBe('no-cache')
+      expect(response.headers['x-custom-header']).toBeUndefined()
+      expect(response.headers['set-cookie']).toBeUndefined()
     })
 
     test('returns upstream status code to caller', async () => {

--- a/test/integration/routes/proxy/kits-proxy.router.test.js
+++ b/test/integration/routes/proxy/kits-proxy.router.test.js
@@ -184,6 +184,28 @@ describe('KITS Proxy router', () => {
       expect(response.headers['set-cookie']).toBeUndefined()
     })
 
+    test('sets content-encoding: identity on all responses', async () => {
+      mockUpstreamResponse()
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/person/123/summary'
+      })
+
+      expect(response.headers['content-encoding']).toBe('identity')
+    })
+
+    test('sets content-encoding: identity on error responses', async () => {
+      mockUpstreamResponse({ status: 500 })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/internal/extapi/person/123/summary'
+      })
+
+      expect(response.headers['content-encoding']).toBe('identity')
+    })
+
     test('returns upstream status code to caller', async () => {
       mockUpstreamResponse({ status: 404 })
 

--- a/test/integration/routes/proxy/kits-proxy.router.test.js
+++ b/test/integration/routes/proxy/kits-proxy.router.test.js
@@ -51,7 +51,7 @@ const mockUpstreamResponse = ({ body = {}, status = 200, headers = {} } = {}) =>
 
 /**
  * This is a bit of a hybrid integration/unit test.  The proxy route is tested by starting a real
- * Hapi server with, but the upstream is mocked.  This validates routing, header filtering, and status code
+ * Hapi server, but the upstream is mocked.  This validates routing, header filtering, and status code
  * pass-through without a live upstream.
  */
 describe('KITS Proxy router', () => {


### PR DESCRIPTION
## Proxy endpoints

Adds a KITS proxy endpoint so that both internal and external KITS endpoints are now exposed

For example, to access the internal KITS endpoint 

> /extapi/person/5858232/summary

the following endpoint on the mock can be used

>/proxy/internal/extapi/person/5858232/summary

(and simply replace internal, for external to achieve the same for the external api)

## Docker containers

In addition to the existing docker-compose file, that creates a simple DAL mock, the following setups are avaialble
* Dal Mock (Proxy endpoint)  ---MTLS---> KITS Simulator  (launched via run-dal-downstream-and-mtls-kits-upstream.sh)
* (MTLS Protected) KITS Simulator (launched via run-proxy-upstream-with-mtls-kits.sh)
  * With this setup you can also run `npm run dev-with-locally-proxied-kits` to launch the mock outside docker, that is able to communicate with the docker MTLS protected KITS simulator  

## Check schema

The check-schema script can now run against KITS again, using the proxy endpoint
