### PR TITLE
Chore/dev security hardening

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           npm audit --omit=dev
           npm ci
+          npm run postinstall
           npm run lint
           npm t
 

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -29,7 +29,10 @@ jobs:
           cache: npm
 
       - name: Install, lint, & test
-        run: npm cit
+        run: |
+          npm ci
+          npm run postinstall
+          npm test
 
       - name: Publish Hot Fix
         uses: DEFRA/cdp-build-action/build-hotfix@main

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+save-exact=true
+ignore-scripts=true
+min-release-age=7
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --chown=node:node .npmrc ./
 RUN npm install
 COPY --chown=node:node src ./src
 
-CMD [ "nodemon", "--ext", "js,json", "--legacy-watch", "./src" ]
+CMD [ "./node_modules/.bin/nodemon", "--ext", "js,json", "--legacy-watch", "./src" ]
 
 FROM defradigital/node:${PARENT_VERSION} AS production
 ARG PARENT_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV PORT=${PORT}
 EXPOSE ${PORT} ${PORT_DEBUG}
 
 COPY --chown=node:node package*.json ./
+COPY --chown=node:node .npmrc ./
 RUN npm install
 COPY --chown=node:node src ./src
 
@@ -28,6 +29,8 @@ RUN apk add --no-cache curl
 USER node
 
 COPY package*.json ./
+COPY .npmrc ./
+
 RUN npm ci --omit=dev
 
 COPY src ./src

--- a/README.md
+++ b/README.md
@@ -40,11 +40,50 @@ nvm use
 
 ### Setup
 
+#### Install application dependencies
+
 Install application dependencies:
 
 ```bash
 npm install
 ```
+
+#### Implicit lifecycle scripts are disabled
+
+Due to the prevalence of NPM supply-chain attacks, scripts that would usually be run during npm install (and also
+pre/post scripts that are run alongside the target script) have been forcibly disabled with the following
+setting in `.npmrc`:
+
+```.npmrc
+ignore-scripts=true
+```
+
+All required post install steps have been gathered into a `postinstall` script. This script contains calls to commands
+that would have been run by 3rd party library installers, if `ignore-scripts` had not been set. The commands in this
+file have been limited to those that are required for our build process. It would still be prudent to examine this script,
+prior to running to ensure that you understand what will be run (you will be prompted to confirm at each step). To run
+this script, execute the following:
+
+```bash
+npm run postinstall
+```
+
+#### 3rd party libraries must be at least 7 days old before they can be installed
+
+The `.npmrc` setting below prevents libraries that have been released in the past 7 days from being installed.
+
+```.npmrc
+min-release-age=7
+```
+
+This gives the npm community time to detect a compromised release before this repo consumes it.
+
+This does create a potential issue. If `npm audit` identifies an issue that must be fixed, and the patched library
+has been released less than 7 days ago, then you will need to investigate the library in question:
+
+- Look at the published release
+- Verify that it's safe
+- Run `npm install {your-dependency}@{version-number} --min-release-age=0` (including `--save-dev` if it's a dev only dependency)
 
 ### Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -964,9 +964,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
-      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.2.tgz",
+      "integrity": "sha512-OKyCOTjNR1hftwSjk9ueyAQTw8AwapvzBrPIWMGn39vhR5PmqLdYFmLc35bsSBye7gSMnlkXfc679bUdMIcRyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -1198,9 +1198,9 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
-      "integrity": "sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.2.tgz",
+      "integrity": "sha512-3dMnV2pfhQiyEqu8DL3VBmxkdLiRDiiUDuG79Dp+UK1gL9ZxAfDOUhB6k3D5MLqcgJJ1IARyGFhwoc1NITr/pg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
@@ -2039,21 +2039,20 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -2064,9 +2063,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2202,9 +2201,9 @@
       }
     },
     "node_modules/@redocly/cli/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2685,9 +2684,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7268,9 +7267,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8129,9 +8128,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
-      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -8139,15 +8138,15 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "NODE_ENV=development nodemon --ext js,json -w ./src",
     "dev-with-locally-proxied-kits": "NODE_ENV=development dotenv -e .env.mtls -- nodemon --ext js,json -w ./src",
     "git:pre-commit-hook": "npm run lint",
-    "postinstall": "npm run setup:husky",
+    "postinstall": "./scripts/post-install.sh",
     "lint": "eslint . && prettier --check . && npm run verify:schemata",
     "lint:fix": "eslint . --fix && prettier --log-level warn --write .",
     "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+export PATH="./node_modules/.bin:$PATH"
+
+echo ""
+echo "npm scripts are disabled in this project (ignore-scripts=true) to defend against supply chain attacks."
+echo "The following mandatory post-install scripts will now be executed."
+if [ "${CI:-false}" != "true" ]; then
+  echo "You will be prompted to confirm each command before it runs."
+fi
+echo ""
+
+confirm_and_run() {
+  if [ "${CI:-false}" != "true" ]; then
+    printf 'You are about to run: %s\n' "$*"
+    read -r -p "Please verify you are happy with the integrity of this command before proceeding. Enter yes to confirm [yes]: " response
+    response="${response:-yes}"
+    if [ "$response" != "yes" ]; then
+      echo "Skipped."
+      return 0
+    fi
+  fi
+  "$@"
+}
+
+# Make prettier executable
+confirm_and_run chmod +x ./node_modules/.bin/prettier
+
+# Configure git hooks path — skipped outside a git repository (e.g. Docker builds)
+if [ -d '.git' ]; then
+  confirm_and_run npm run setup:husky
+else
+  echo "Skipping husky: not a git repository."
+fi
+


### PR DESCRIPTION
Implement the stricter security setup advised for all DEFRA Node projects.

### Disable scripts
The main change is to disable automatically running NPM lifecycle scripts.

This means that any script executed during `npm install` and any npm lifecycle scripts (such as `prepare`, `preXXXX` and `postXXXX`) are no longer executed.

To work around this, the following changes have been made:
* a new `postinstall` script has been added.  This must be manually run locally and will
  * setup husky 
  * make the prettier binary executabe
* update Dockerfile to disable script execution
* ensure that github actions run the required postinstall steps 
* Details of all relevant changes have been added to the README

### Implement a min-age rule for libraries
In addition to disabling scripts, we have also disabled installation of npm libraries that are less than 7 days old.  This gives the community time to identify critical supply chain vulnerabilities.

This addresses [FCPDAL-383](https://eaflood.atlassian.net/browse/FCPDAL-383)

[FCPDAL-383]: https://eaflood.atlassian.net/browse/FCPDAL-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ