### PR TITLE
Feat/add land apis

### DIFF
--- a/src/factories/land/land.factory.js
+++ b/src/factories/land/land.factory.js
@@ -1,5 +1,5 @@
 import { Boom } from '@hapi/boom'
-import { orgIdToSbi } from '../../factories/id-lookups.js'
+import { orgIdToSbi } from '../id-lookups.js'
 import { getLandParcels } from '../common-land.js'
 import { faker, safeSeed } from '../common.js'
 
@@ -102,13 +102,18 @@ export const retrieveParcelDetails = (orgId) => {
   }))
 }
 
-export const retrieveCovers = (orgId, sheetId, parcelId) => {
+export const retrieveCovers = (orgId, sheetId, parcelId, includeGeometries) => {
   const { covers: orgCovers } = retrieveOrgLand(orgId)
   // API returns empty array if no covers found even if invalid parcel reference
   const covers = orgCovers[`${sheetId}-${parcelId}`] || []
+
+  const features = includeGeometries
+    ? covers
+    : covers.map((cover) => ({ ...cover, geometry: null }))
+
   return {
     type: 'FeatureCollection',
-    features: covers
+    features
   }
 }
 

--- a/src/factories/land/land.factory.js
+++ b/src/factories/land/land.factory.js
@@ -117,6 +117,23 @@ export const retrieveCovers = (orgId, sheetId, parcelId, includeGeometries) => {
   }
 }
 
+export const retrieveParcelGeometries = (orgId) => {
+  const { parcelsDetailsGeo } = retrieveOrgLand(orgId)
+  return {
+    features: parcelsDetailsGeo.map(({ parcel }) => ({
+      id: parcel.id,
+      type: 'Feature',
+      geometry: parcel.geometry,
+      properties: {
+        sheetId: parcel.properties.sheetId,
+        parcelId: parcel.properties.parcelId,
+        area: String(parcel.properties.area),
+        pendingDigitisation: String(parcel.properties.pendingDigitisation)
+      }
+    }))
+  }
+}
+
 export const retrieveCoversSummary = (orgId) => {
   // Strangely this API does actually throw an error for non-existent orgId
   if (!orgIdToSbi[orgId]) {

--- a/src/plugins/schemata.js
+++ b/src/plugins/schemata.js
@@ -39,6 +39,13 @@ export const schemata = {
         },
         {
           method: 'GET',
+          path: '/schemata/land.yml',
+          handler: {
+            file: path.join(__dirname, '../routes/kits-v1/land-schema.oas.yml')
+          }
+        },
+        {
+          method: 'GET',
           path: '/schemata/bank.yml',
           handler: {
             file: path.join(__dirname, '../routes/kits-v1/bank-schema.oas.yml')

--- a/src/routes/kits-v1/land-schema.oas.yml
+++ b/src/routes/kits-v1/land-schema.oas.yml
@@ -34,12 +34,19 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ParcelNoGeometry'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
+        '403':
+          description: Returned by upstream if organisationId has an invalid format
+          content:
+            text/html:
+              schema:
+                type: string
         '500':
-          $ref: '#/components/responses/InternalError'
+          description: Returned by upstream if historicDate has an invalid format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /lms/organisation/{organisationId}/parcel-details/historic/{historicDate}:
     get:
       tags:
@@ -60,12 +67,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ParcelDetails'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalError'
+        '403':
+          description: Returned by upstream if organisationId or historicDate has an invalid format
+          content:
+            text/html:
+              schema:
+                type: string
+
   /lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers:
     get:
       tags:
@@ -75,8 +83,6 @@ paths:
       description: |
         Returns land covers for a parcel at `historicDate`. Calls
         `parcelService.getParcelLandCovers(sheetId, parcelId, historicDate, includeGeometries)`.
-
-        **Authorization**: VIEWLAND required.
       parameters:
         - $ref: '#/components/parameters/organisationId'
         - $ref: '#/components/parameters/sheetId'
@@ -87,8 +93,8 @@ paths:
           required: false
           description: Whether to include geometry data. Default false.
           schema:
-            type: boolean
-            default: false
+            type: string
+            default: 'false'
       responses:
         '200':
           description: Land cover feature collection at historic date
@@ -96,12 +102,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CapdFeatureCollectionLandCovers'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalError'
+        '403':
+          description: Returned by upstream if any of the parameters are badly formed
+          content:
+            text/html:
+              schema:
+                type: string
 
   /lms/organisation/{organisationId}/covers-summary/historic/{historicDate}:
     get:
@@ -125,10 +131,19 @@ paths:
                   $ref: '#/components/schemas/AreaInfo'
         '400':
           $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
+        '403':
+          description: Returned by upstream if historicDate has an invalid format
+          content:
+            text/html:
+              schema:
+                type: string
         '500':
-          $ref: '#/components/responses/InternalError'
+          description: Returned by upstream if org can't be found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /lms/organisation/{organisationId}/geometries:
     get:
       tags:
@@ -148,7 +163,7 @@ paths:
           schema:
             type: string
             minLength: 1
-            example: '-2.5,51.2,-1.5,52.0'
+            examples: ['0,0,0,0']
         - name: group
           in: query
           required: false
@@ -163,17 +178,30 @@ paths:
             type: string
       responses:
         '200':
-          description: GeoJSON feature collection of parcel geometries
+          description: GeoJSON feature collection of parcel geometries (empty feature list if organisationId/bbox combination results in no match)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CapdFeatureCollectionParcel'
         '400':
-          $ref: '#/components/responses/BadRequest'
+          description: Returned by upstream if bounding box is not supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalError'
+          description: Returned by upstream if bounding box is not formatted correctly
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Returned by upstream if organisationId has an invalid format
+          content:
+            text/html:
+              schema:
+                type: string
+
 components:
   parameters:
     organisationId:
@@ -184,6 +212,7 @@ components:
       schema:
         type: integer
         format: int64
+        examples: [1111111111]
     historicDate:
       name: historicDate
       in: path
@@ -192,7 +221,7 @@ components:
         Date for historical data retrieval. Format: `DD-MMM-YY` date string (e.g. `19-Jul-24`).
       schema:
         type: string
-        example: '19-Jul-24'
+        examples: ['19-Jul-24']
     sheetId:
       name: sheetId
       in: path
@@ -200,6 +229,7 @@ components:
       description: OS map sheet identifier
       schema:
         type: string
+        examples: ['SS6627']
     parcelId:
       name: parcelId
       in: path
@@ -207,6 +237,7 @@ components:
       description: Parcel identifier within the OS sheet
       schema:
         type: string
+        examples: ['5662']
 
   securitySchemes:
     mTLS:
@@ -229,12 +260,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
-    InternalError:
-      description: Unexpected service error
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
+
   schemas:
     ErrorResponse:
       type: object

--- a/src/routes/kits-v1/land-schema.oas.yml
+++ b/src/routes/kits-v1/land-schema.oas.yml
@@ -1,0 +1,269 @@
+openapi: 3.1.0
+info:
+  title: CAPD LMS Land View Service
+  description: |
+    Read-only service providing land parcel information, land cover data, geometries, and
+    spatial summaries from LMS (Land Management System).
+  version: '1.0.0'
+  license:
+    name: 'Open Government Licence v3.0'
+    url: 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3'
+security:
+  - mTLS: []
+servers:
+  - url: 'https://chs-upgrade-api.ruraldev.org.uk:8446/extapi'
+    description: The test server for KITS/V1 APIs
+paths:
+  /lms/organisation/{organisationId}/parcels/historic/{historicDate}:
+    get:
+      tags:
+        - organisation
+      summary: Get all parcels for an organisation at a historic date
+      operationId: getParcelsHistoric
+      description: |
+        Returns all parcels as they existed at `historicDate`. Calls
+        `organisationService.getParcels(historicDate, organisationId)`.
+
+        **Authorization**: VIEWLAND required.
+      parameters:
+        - $ref: '#/components/parameters/organisationId'
+        - $ref: '#/components/parameters/historicDate'
+      responses:
+        '200':
+          description: Parcel list at historic date
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ParcelNoGeometry'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /lms/organisation/{organisationId}/parcel-details/historic/{historicDate}:
+    get:
+      tags:
+        - organisation
+      summary: Get all parcel details at a historic date
+      operationId: getParcelDetailsHistoric
+      description: |
+        Returns detailed parcel records for all parcels at `historicDate`. Calls
+        `organisationService.getParcelDetails(organisationId, historicDate)`.
+
+        **Authorization**: VIEWLAND required.
+      parameters:
+        - $ref: '#/components/parameters/organisationId'
+        - $ref: '#/components/parameters/historicDate'
+      responses:
+        '200':
+          description: All parcel details at historic date
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ParcelDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers:
+    get:
+      tags:
+        - parcel
+      summary: Get land covers for a parcel at a historic date
+      operationId: getParcelLandCoversHistoric
+      description: |
+        Returns land covers for a parcel at `historicDate`. Calls
+        `parcelService.getParcelLandCovers(sheetId, parcelId, historicDate, includeGeometries)`.
+
+        **Authorization**: VIEWLAND required.
+      parameters:
+        - $ref: '#/components/parameters/organisationId'
+        - $ref: '#/components/parameters/sheetId'
+        - $ref: '#/components/parameters/parcelId'
+        - $ref: '#/components/parameters/historicDate'
+        - name: includeGeometries
+          in: query
+          required: false
+          description: |
+            Whether to include geometry data. Treated as `true` only when the value
+            (case-insensitive) is the string "true"; any other value is treated as `false`.
+          schema:
+            type: string
+            default: 'false'
+      responses:
+        '200':
+          description: Land cover feature collection at historic date
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapdFeatureCollectionLandCovers'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+components:
+  parameters:
+    organisationId:
+      name: organisationId
+      in: path
+      required: true
+      description: Internal organisation identifier (Long)
+      schema:
+        type: string
+    historicDate:
+      name: historicDate
+      in: path
+      required: true
+      description: |
+        Date for historical data retrieval. Format: `DD-MMM-YY` date string (e.g. `19-Jul-24`).
+      schema:
+        type: string
+        example: '19-Jul-24'
+    sheetId:
+      name: sheetId
+      in: path
+      required: true
+      description: OS map sheet identifier
+      schema:
+        type: string
+    parcelId:
+      name: parcelId
+      in: path
+      required: true
+      description: Parcel identifier within the OS sheet
+      schema:
+        type: string
+
+  securitySchemes:
+    mTLS:
+      type: mutualTLS
+      description: >
+        Mutual TLS authentication. Client must present a certificate issued by the server.
+
+  responses:
+    BadRequest:
+      description: |
+        Validation error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: |
+        Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    InternalError:
+      description: Unexpected service error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+    ParcelNoGeometry:
+      type: object
+      x-validation-source: ParcelNoGeometry.java (entity)
+      description: |
+        Land parcel record without geometry. Stored in LMS database.
+        `validFrom`/`validTo` are `@Transient` (not in DB, populated from queries).
+      properties:
+        id:
+          type: integer
+          description: Unique parcel identifier (BigInteger)
+        sheetId:
+          type: string
+          description: OS map sheet identifier
+        parcelId:
+          type: string
+          description: Parcel identifier within the sheet
+        area:
+          type: number
+          description: Parcel area (typically in hectares)
+        pendingDigitisation:
+          type: boolean
+          description: True if the parcel is awaiting digitisation. Defaults to false.
+        validFrom:
+          type: ['string', 'null']
+          description: Parcel validity start date (transient — from query)
+        validTo:
+          type: ['string', 'null']
+          description: Parcel validity end date (transient — from query)
+
+    ParcelDetails:
+      type: object
+      x-validation-source: ParcelDetails.java
+      description: Detailed parcel record with explicit validity dates.
+      properties:
+        sheetId:
+          type: string
+        parcelId:
+          type: string
+        validFrom:
+          type: integer
+          description: Validity start date as epoch milliseconds
+        validTo:
+          type: integer
+          description: Validity end date as epoch milliseconds
+    CapdFeatureCollectionLandCovers:
+      type: object
+      description: GeoJSON-style feature collection of land cover features.
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/LandCoverDTO'
+    LandCoverDTO:
+      type: object
+      x-validation-source: LandCoverDTO.java
+      description: |
+        GeoJSON Feature for a land cover entry. `properties` map contains: code, name,
+        area (as string), isBpsEligible (as string). `geometry` may be null if
+        `includeGeometries=false`.
+      properties:
+        id:
+          type: number
+          description: Unique land cover identifier
+        type:
+          type: string
+          description: GeoJSON type (always "Feature")
+          example: Feature
+        geometry:
+          description: Null when the request specified `includeGeometries=false`.
+          oneOf:
+            - $ref: '#/components/schemas/GeoJsonGeometry'
+            - type: 'null'
+        properties:
+          type: object
+          description: |
+            Land cover properties map. Keys: code, name, area, isBpsEligible.
+          additionalProperties:
+            type: string
+    GeoJsonGeometry:
+      type: object
+      x-schema-incomplete: true
+      description: |
+        JTS Geometry serialised as GeoJSON. Type may be Polygon, MultiPolygon, Point, etc.
+        Exact structure depends on the parcel geometry stored in LMS.
+      properties:
+        type:
+          type: string
+          example: Polygon
+        coordinates:
+          type: array
+          description: GeoJSON coordinate array (structure depends on type)
+          items: {}

--- a/src/routes/kits-v1/land-schema.oas.yml
+++ b/src/routes/kits-v1/land-schema.oas.yml
@@ -156,6 +156,7 @@ paths:
             Pass `0,0,0,0` to retrieve all geometries (bypasses spatial filter, uses cache).
           schema:
             type: string
+            minLength: 1
             example: '-2.5,51.2,-1.5,52.0'
         - name: group
           in: query

--- a/src/routes/kits-v1/land-schema.oas.yml
+++ b/src/routes/kits-v1/land-schema.oas.yml
@@ -21,10 +21,7 @@ paths:
       summary: Get all parcels for an organisation at a historic date
       operationId: getParcelsHistoric
       description: |
-        Returns all parcels as they existed at `historicDate`. Calls
-        `organisationService.getParcels(historicDate, organisationId)`.
-
-        **Authorization**: VIEWLAND required.
+        Returns all parcels as they existed at `historicDate`.
       parameters:
         - $ref: '#/components/parameters/organisationId'
         - $ref: '#/components/parameters/historicDate'
@@ -50,10 +47,7 @@ paths:
       summary: Get all parcel details at a historic date
       operationId: getParcelDetailsHistoric
       description: |
-        Returns detailed parcel records for all parcels at `historicDate`. Calls
-        `organisationService.getParcelDetails(organisationId, historicDate)`.
-
-        **Authorization**: VIEWLAND required.
+        Returns detailed parcel records for all parcels at `historicDate`.
       parameters:
         - $ref: '#/components/parameters/organisationId'
         - $ref: '#/components/parameters/historicDate'
@@ -116,10 +110,7 @@ paths:
       summary: Get aggregated land cover summary at a historic date
       operationId: getLandCoverSummaryHistoric
       description: |
-        Returns aggregated land cover area totals at `historicDate`. Calls
-        `organisationService.getLandCoverSummary(businessReference, historicDate)`.
-
-        **Authorization**: VIEWLAND required.
+        Returns aggregated land cover area totals at `historicDate`.
       parameters:
         - $ref: '#/components/parameters/organisationId'
         - $ref: '#/components/parameters/historicDate'
@@ -153,7 +144,7 @@ paths:
           required: true
           description: |
             Bounding box as comma-separated string: `left,bottom,right,top` (minLon,minLat,maxLon,maxLat).
-            Pass `0,0,0,0` to retrieve all geometries (bypasses spatial filter, uses cache).
+            Pass `0,0,0,0` to retrieve all geometries
           schema:
             type: string
             minLength: 1
@@ -161,13 +152,13 @@ paths:
         - name: group
           in: query
           required: false
-          description: Optional group filter. Part of the cache key when bbox is undefined.
+          description: Optional group filter. (Not used by mock)
           schema:
             type: string
         - name: historicDate
           in: query
           required: false
-          description: Optional historic date filter. Part of the cache key when bbox is undefined.
+          description: Optional historic date filter.
           schema:
             type: string
       responses:
@@ -256,8 +247,7 @@ components:
       type: object
       x-validation-source: ParcelNoGeometry.java (entity)
       description: |
-        Land parcel record without geometry. Stored in LMS database.
-        `validFrom`/`validTo` are `@Transient` (not in DB, populated from queries).
+        Land parcel record without geometry.
       properties:
         id:
           type: integer

--- a/src/routes/kits-v1/land-schema.oas.yml
+++ b/src/routes/kits-v1/land-schema.oas.yml
@@ -138,7 +138,50 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
-
+  /lms/organisation/{organisationId}/geometries:
+    get:
+      tags:
+        - organisation
+      summary: Get parcel geometries (GeoJSON feature collection) with bounding box filter
+      operationId: getParcelsGeometries
+      description: |
+        Returns parcel geometries as a GeoJSON feature collection, filtered by `bbox`.
+      parameters:
+        - $ref: '#/components/parameters/organisationId'
+        - name: bbox
+          in: query
+          required: true
+          description: |
+            Bounding box as comma-separated string: `left,bottom,right,top` (minLon,minLat,maxLon,maxLat).
+            Pass `0,0,0,0` to retrieve all geometries (bypasses spatial filter, uses cache).
+          schema:
+            type: string
+            example: '-2.5,51.2,-1.5,52.0'
+        - name: group
+          in: query
+          required: false
+          description: Optional group filter. Part of the cache key when bbox is undefined.
+          schema:
+            type: string
+        - name: historicDate
+          in: query
+          required: false
+          description: Optional historic date filter. Part of the cache key when bbox is undefined.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: GeoJSON feature collection of parcel geometries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapdFeatureCollectionParcel'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
 components:
   parameters:
     organisationId:
@@ -252,6 +295,38 @@ components:
         validTo:
           type: integer
           description: Validity end date as epoch milliseconds
+    ParcelWithGeometryDTO:
+      type: object
+      x-validation-source: ParcelWithGeometryDTO.java
+      description: |
+        GeoJSON Feature representing a parcel with full geometry. The `properties` map
+        contains: sheetId, parcelId, area (as string), pendingDigitisation (as string).
+        `type` is hardcoded as "Feature".
+      properties:
+        id:
+          type: integer
+          description: Unique parcel identifier
+        type:
+          type: string
+          description: GeoJSON type (always "Feature")
+          example: Feature
+        geometry:
+          $ref: '#/components/schemas/GeoJsonGeometry'
+        properties:
+          type: object
+          description: |
+            Feature properties map. Keys: sheetId, parcelId, area, pendingDigitisation.
+          additionalProperties:
+            type: string
+    CapdFeatureCollectionParcel:
+      type: object
+      description: GeoJSON-style feature collection of parcel geometries.
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParcelWithGeometryDTO'
+
     CapdFeatureCollectionLandCovers:
       type: object
       description: GeoJSON-style feature collection of land cover features.

--- a/src/routes/kits-v1/land-schema.oas.yml
+++ b/src/routes/kits-v1/land-schema.oas.yml
@@ -66,6 +66,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ParcelDetails'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -89,12 +91,10 @@ paths:
         - name: includeGeometries
           in: query
           required: false
-          description: |
-            Whether to include geometry data. Treated as `true` only when the value
-            (case-insensitive) is the string "true"; any other value is treated as `false`.
+          description: Whether to include geometry data. Default false.
           schema:
-            type: string
-            default: 'false'
+            type: boolean
+            default: false
       responses:
         '200':
           description: Land cover feature collection at historic date
@@ -102,6 +102,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CapdFeatureCollectionLandCovers'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /lms/organisation/{organisationId}/covers-summary/historic/{historicDate}:
+    get:
+      tags:
+        - organisation
+      summary: Get aggregated land cover summary at a historic date
+      operationId: getLandCoverSummaryHistoric
+      description: |
+        Returns aggregated land cover area totals at `historicDate`. Calls
+        `organisationService.getLandCoverSummary(businessReference, historicDate)`.
+
+        **Authorization**: VIEWLAND required.
+      parameters:
+        - $ref: '#/components/parameters/organisationId'
+        - $ref: '#/components/parameters/historicDate'
+      responses:
+        '200':
+          description: Aggregated land cover summary at historic date
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AreaInfo'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -115,7 +147,8 @@ components:
       required: true
       description: Internal organisation identifier (Long)
       schema:
-        type: string
+        type: integer
+        format: int64
     historicDate:
       name: historicDate
       in: path
@@ -267,3 +300,17 @@ components:
           type: array
           description: GeoJSON coordinate array (structure depends on type)
           items: {}
+    AreaInfo:
+      type: object
+      x-validation-source: EligibleLandCoversInfo.AreaInfo (nested class)
+      description: Land cover area breakdown entry.
+      properties:
+        code:
+          type: string
+          description: Land cover classification code
+        name:
+          type: string
+          description: Land cover type name
+        area:
+          type: number
+          description: Area of this land cover type (in hectares)

--- a/src/routes/kits-v1/land.js
+++ b/src/routes/kits-v1/land.js
@@ -54,9 +54,9 @@ export const land = [
       const { sheetId, parcelId } = request.params
 
       const organisationId = extractOrganisationId(request)
-      extractIncludeGeometries(request)
+      const includeGeometries = extractIncludeGeometries(request)
 
-      const covers = retrieveCovers(organisationId, sheetId, parcelId)
+      const covers = retrieveCovers(organisationId, sheetId, parcelId, includeGeometries)
       return h.response(covers)
     }
   },

--- a/src/routes/kits-v1/land.js
+++ b/src/routes/kits-v1/land.js
@@ -15,6 +15,25 @@ const extractOrganisationId = (request) => {
   return organisationId
 }
 
+const validateBbox = (request) => {
+  const { bbox } = request.query
+
+  if (!bbox) {
+    throw Boom.badRequest('bbox query parameter must be specified')
+  }
+
+  // Upstream returns 404 (not 400) if bbox isn't exactly 4 comma-separated numbers
+  const coordinates = bbox.split(',')
+  if (
+    coordinates.length !== 4 ||
+    !coordinates.every((coordinate) => /^[+-]?\d*\.?\d+$/.test(coordinate))
+  ) {
+    throw Boom.notFound()
+  }
+
+  return bbox
+}
+
 const extractIncludeGeometries = (request) => {
   const { includeGeometries } = request.query
   if (
@@ -77,12 +96,11 @@ export const land = [
     handler: async (request, h) => {
       const organisationId = extractOrganisationId(request)
 
-      // bbox is required by the upstream API but the mock doesn't spatially filter on
-      // it - the generated parcel geometries aren't tied to real-world coordinates, so
-      // all of the org's parcel geometries are returned regardless of bbox/historicDate.
-      if (!request.query.bbox) {
-        throw Boom.badRequest('bbox query parameter must be specified')
-      }
+      // bbox is required and validated by the upstream API but the mock doesn't
+      // spatially filter on it - the generated parcel geometries aren't tied to
+      // real-world coordinates, so all the org's parcel geometries are returned
+      // regardless of bbox/historicDate.
+      validateBbox(request)
 
       const geometries = retrieveParcelGeometries(organisationId)
       return h.response(geometries)

--- a/src/routes/kits-v1/land.js
+++ b/src/routes/kits-v1/land.js
@@ -2,6 +2,7 @@ import {
   retrieveCovers,
   retrieveCoversSummary,
   retrieveParcelDetails,
+  retrieveParcelGeometries,
   retrieveParcels
 } from '../../factories/land/land.factory.js'
 import Boom from '@hapi/boom'
@@ -68,6 +69,23 @@ export const land = [
 
       const coversSummary = retrieveCoversSummary(organisationId)
       return h.response(coversSummary)
+    }
+  },
+  {
+    method: 'GET',
+    path: '/lms/organisation/{organisationId}/geometries',
+    handler: async (request, h) => {
+      const organisationId = extractOrganisationId(request)
+
+      // bbox is required by the upstream API but the mock doesn't spatially filter on
+      // it - the generated parcel geometries aren't tied to real-world coordinates, so
+      // all of the org's parcel geometries are returned regardless of bbox/historicDate.
+      if (!request.query.bbox) {
+        throw Boom.badRequest('bbox query parameter must be specified')
+      }
+
+      const geometries = retrieveParcelGeometries(organisationId)
+      return h.response(geometries)
     }
   }
 ]

--- a/src/routes/kits-v1/land.js
+++ b/src/routes/kits-v1/land.js
@@ -4,13 +4,35 @@ import {
   retrieveParcelDetails,
   retrieveParcels
 } from '../../factories/land/land.factory.js'
+import Boom from '@hapi/boom'
+
+const extractOrganisationId = (request) => {
+  const organisationId = request.params.organisationId
+  if (!Number.isInteger(Number(organisationId))) {
+    throw Boom.badRequest(`Bad request`)
+  }
+  return organisationId
+}
+
+const extractIncludeGeometries = (request) => {
+  const { includeGeometries } = request.query
+  if (
+    includeGeometries !== undefined &&
+    !['true', 'false'].includes(includeGeometries.toLowerCase())
+  ) {
+    throw Boom.badRequest(`invalid includeGeometries: ${includeGeometries}`)
+  }
+
+  return includeGeometries?.toLowerCase() === 'true'
+}
 
 export const land = [
   {
     method: 'GET',
     path: '/lms/organisation/{organisationId}/parcels/historic/{historicDate}',
     handler: async (request, h) => {
-      const organisationId = request.params.organisationId
+      const organisationId = extractOrganisationId(request)
+
       const parcels = retrieveParcels(organisationId)
       return h.response(parcels)
     }
@@ -19,7 +41,8 @@ export const land = [
     method: 'GET',
     path: '/lms/organisation/{organisationId}/parcel-details/historic/{historicDate}',
     handler: async (request, h) => {
-      const organisationId = request.params.organisationId
+      const organisationId = extractOrganisationId(request)
+
       const parcelDetails = retrieveParcelDetails(organisationId)
       return h.response(parcelDetails)
     }
@@ -28,7 +51,11 @@ export const land = [
     method: 'GET',
     path: '/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers',
     handler: async (request, h) => {
-      const { sheetId, parcelId, organisationId } = request.params
+      const { sheetId, parcelId } = request.params
+
+      const organisationId = extractOrganisationId(request)
+      extractIncludeGeometries(request)
+
       const covers = retrieveCovers(organisationId, sheetId, parcelId)
       return h.response(covers)
     }
@@ -37,7 +64,8 @@ export const land = [
     method: 'GET',
     path: '/lms/organisation/{organisationId}/covers-summary/historic/{historicDate}',
     handler: async (request, h) => {
-      const { organisationId } = request.params
+      const organisationId = extractOrganisationId(request)
+
       const coversSummary = retrieveCoversSummary(organisationId)
       return h.response(coversSummary)
     }

--- a/src/routes/kits-v1/land.js
+++ b/src/routes/kits-v1/land.js
@@ -6,11 +6,15 @@ import {
   retrieveParcels
 } from '../../factories/land/land.factory.js'
 import Boom from '@hapi/boom'
+import { createLogger } from '../../common/helpers/logging/logger.js'
+
+const logger = createLogger('land.route')
 
 const extractOrganisationId = (request) => {
   const organisationId = request.params.organisationId
   if (!Number.isInteger(Number(organisationId))) {
-    throw Boom.badRequest(`Bad request`)
+    logger.warn(`Badly formed organisation ID (${organisationId})`)
+    throw Boom.forbidden()
   }
   return organisationId
 }
@@ -26,8 +30,9 @@ const validateBbox = (request) => {
   const coordinates = bbox.split(',')
   if (
     coordinates.length !== 4 ||
-    !coordinates.every((coordinate) => /^[+-]?\d*\.?\d+$/.test(coordinate))
+    coordinates.some((coordinate) => Number.isNaN(Number.parseFloat(coordinate)))
   ) {
+    logger.warn('bbox must contain 4 comma separated numbers')
     throw Boom.notFound()
   }
 
@@ -36,14 +41,17 @@ const validateBbox = (request) => {
 
 const extractIncludeGeometries = (request) => {
   const { includeGeometries } = request.query
-  if (
-    includeGeometries !== undefined &&
-    !['true', 'false'].includes(includeGeometries.toLowerCase())
-  ) {
-    throw Boom.badRequest(`invalid includeGeometries: ${includeGeometries}`)
-  }
-
   return includeGeometries?.toLowerCase() === 'true'
+}
+
+// Dates must have format DD-MMM-YY (e.g. 10-Jul-24)
+const HISTORIC_DATE_PATTERN = /^\d{2}-[A-Za-z]{3}-\d{2}$/
+
+const validateHistoricDate = (request, errorFunction) => {
+  const { historicDate } = request.params
+  if (!HISTORIC_DATE_PATTERN.test(historicDate)) {
+    throw errorFunction()
+  }
 }
 
 export const land = [
@@ -52,6 +60,7 @@ export const land = [
     path: '/lms/organisation/{organisationId}/parcels/historic/{historicDate}',
     handler: async (request, h) => {
       const organisationId = extractOrganisationId(request)
+      validateHistoricDate(request, Boom.internal)
 
       const parcels = retrieveParcels(organisationId)
       return h.response(parcels)
@@ -62,6 +71,7 @@ export const land = [
     path: '/lms/organisation/{organisationId}/parcel-details/historic/{historicDate}',
     handler: async (request, h) => {
       const organisationId = extractOrganisationId(request)
+      validateHistoricDate(request, Boom.forbidden)
 
       const parcelDetails = retrieveParcelDetails(organisationId)
       return h.response(parcelDetails)
@@ -85,6 +95,7 @@ export const land = [
     path: '/lms/organisation/{organisationId}/covers-summary/historic/{historicDate}',
     handler: async (request, h) => {
       const organisationId = extractOrganisationId(request)
+      validateHistoricDate(request, Boom.forbidden)
 
       const coversSummary = retrieveCoversSummary(organisationId)
       return h.response(coversSummary)

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -72,8 +72,7 @@ case "$1" in
 .components.parameters.sheetId.schema.examples = ["TL8951"] |
 .components.parameters.parcelId.schema.examples = ["3227"] |
 .components.parameters.historicDate.schema.examples = ["19-Jul-24"] |
-.paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = [true, false] |
-.paths["/lms/organisation/{organisationId}/geometries"].get.parameters[1].schema.examples = ["0,0,0,0"]'
+.paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = [true, false]'
     kits=true
     ;;
   o | org | organisation )

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -18,6 +18,7 @@ usage() {
   echo "Where the argument specifies which schema to test:"
   echo "  a  | auth | authenticate - test the Authenticate schema"
   echo "  b  | bank                - test the Bank Change Service schema"
+  echo "  l  | land                - test the Land schema"
   echo "  o  | org | organisation  - test the Organisation schema"
   echo "  p  | person              - test the Person schema"
   echo "  r  | rd | reference-data - test the Reference Data schema"
@@ -62,6 +63,16 @@ case "$1" in
     schema="kits-v1/authenticate"
     mutations='. |
 .paths["/external-auth/security-answers/{crn}"].get.parameters[0].schema.examples = [1105739979,1106046692,1106077237,1100932879,1105430162]'
+    kits=true
+    ;;
+  l | land )
+    schema="kits-v1/land"
+    mutations='. |
+.components.parameters.organisationId.schema.examples = ["5588135"] |
+.components.parameters.sheetId.schema.examples = ["TL8951"] |
+.components.parameters.parcelId.schema.examples = ["3227"] |
+.components.parameters.historicDate.schema.examples = ["19-Jul-24"] |
+.paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = ["true", "false"]'
     kits=true
     ;;
   o | org | organisation )

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -68,11 +68,11 @@ case "$1" in
   l | land )
     schema="kits-v1/land"
     mutations='. |
-.components.parameters.organisationId.schema.examples = ["5588135"] |
+.components.parameters.organisationId.schema.examples = [5588135] |
 .components.parameters.sheetId.schema.examples = ["TL8951"] |
 .components.parameters.parcelId.schema.examples = ["3227"] |
 .components.parameters.historicDate.schema.examples = ["19-Jul-24"] |
-.paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = ["true", "false"]'
+.paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = [true, false]'
     kits=true
     ;;
   o | org | organisation )

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -72,7 +72,8 @@ case "$1" in
 .components.parameters.sheetId.schema.examples = ["TL8951"] |
 .components.parameters.parcelId.schema.examples = ["3227"] |
 .components.parameters.historicDate.schema.examples = ["19-Jul-24"] |
-.paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = [true, false]'
+.paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = [true, false] |
+.paths["/lms/organisation/{organisationId}/geometries"].get.parameters[1].schema.examples = ["0,0,0,0"]'
     kits=true
     ;;
   o | org | organisation )

--- a/test/contract/compose.yml
+++ b/test/contract/compose.yml
@@ -8,7 +8,7 @@ services:
       - -c
       - |
         result=0
-        for schema in person organisation authenticate siti-agri payments reference-data ; do
+        for schema in person organisation authenticate siti-agri payments land reference-data ; do
           echo "Running contract tests for schema: $${schema}"
           auth_header="email: $${TEST_USER_EMAIL:-testuser01@defra.gov.uk}"
           if [ "$${schema}" = "payments" ]; then auth_header='Authorization: bearer token'; fi

--- a/test/contract/compose.yml
+++ b/test/contract/compose.yml
@@ -8,7 +8,7 @@ services:
       - -c
       - |
         result=0
-        for schema in person organisation authenticate siti-agri payments land reference-data ; do
+        for schema in land ; do
           echo "Running contract tests for schema: $${schema}"
           auth_header="email: $${TEST_USER_EMAIL:-testuser01@defra.gov.uk}"
           if [ "$${schema}" = "payments" ]; then auth_header='Authorization: bearer token'; fi

--- a/test/integration/land-queries.test.js
+++ b/test/integration/land-queries.test.js
@@ -158,9 +158,17 @@ describe('Basic queries for faked routes', () => {
     test('Should throw error for /lms/organisation/{organisationId}/covers-summary/historic/{historicDate} if org does not exist', async () => {
       const response = await mockServer.inject({
         method: 'GET',
-        url: '/extapi/lms/organisation/nonexistent/covers-summary/historic/01-Jan-25'
+        url: '/extapi/lms/organisation/9999999999/covers-summary/historic/01-Jan-25'
       })
       expect(response.statusCode).toBe(500)
+    })
+
+    test('Should return 400 for /lms/organisation/{organisationId}/covers-summary/historic/{historicDate} if organisationId is not numeric', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/nonexistent/covers-summary/historic/01-Jan-25'
+      })
+      expect(response.statusCode).toBe(400)
     })
   })
 })

--- a/test/integration/land-queries.test.js
+++ b/test/integration/land-queries.test.js
@@ -195,5 +195,68 @@ describe('Basic queries for faked routes', () => {
       })
       expect(response.statusCode).toBe(400)
     })
+
+    test('Should return data for /lms/organisation/{organisationId}/geometries', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/geometries?bbox=0,0,0,0'
+      })
+      expect(response.statusCode).toBe(200)
+      const json = JSON.parse(response.payload)
+      expect(json).toEqual({
+        features: expect.arrayContaining([
+          expect.objectContaining({
+            id: 7386091,
+            type: 'Feature',
+            properties: {
+              sheetId: 'SS6627',
+              parcelId: '5662',
+              area: '10270.39',
+              pendingDigitisation: 'false'
+            },
+            geometry: expect.objectContaining({ type: 'Polygon' })
+          })
+        ])
+      })
+    })
+
+    test('Should return 400 for /lms/organisation/{organisationId}/geometries if bbox is missing', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/geometries'
+      })
+      expect(response.statusCode).toBe(400)
+    })
+
+    test('Should return 400 for /lms/organisation/{organisationId}/geometries if bbox is empty', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/geometries?bbox='
+      })
+      expect(response.statusCode).toBe(400)
+    })
+
+    test.each([
+      ['too few coordinates', '1,1,1'],
+      ['too many coordinates', '1,1,1,1,1'],
+      ['non-numeric coordinates', 'a,b,c,d']
+    ])(
+      'Should return 404 for /lms/organisation/{organisationId}/geometries if bbox has %s (%s)',
+      async (_description, bbox) => {
+        const response = await mockServer.inject({
+          method: 'GET',
+          url: `/extapi/lms/organisation/1111111111/geometries?bbox=${bbox}`
+        })
+        expect(response.statusCode).toBe(404)
+      }
+    )
+
+    test('Should return data for /lms/organisation/{organisationId}/geometries if bbox contains signed/leading-zero coordinates', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/geometries?bbox=-1.5,%2B2.0,1,00.1'
+      })
+      expect(response.statusCode).toBe(200)
+    })
   })
 })

--- a/test/integration/land-queries.test.js
+++ b/test/integration/land-queries.test.js
@@ -41,6 +41,22 @@ describe('Basic queries for faked routes', () => {
       )
     })
 
+    test('Should return 403 for /lms/organisation/{organisationId}/parcels/historic/{historicDate} if organisationId is not numeric', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/nonexistent/parcels/historic/01-Jan-25'
+      })
+      expect(response.statusCode).toBe(403)
+    })
+
+    test('Should return 500 for /lms/organisation/{organisationId}/parcels/historic/{historicDate} if historicDate is invalid', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/parcels/historic/invalid'
+      })
+      expect(response.statusCode).toBe(500)
+    })
+
     test('Should return data for /lms/organisation/{organisationId}/parcels/historic/{historicDate} where land is NOT defined in id-lookups for the organisation', async () => {
       const response = await mockServer.inject({
         method: 'GET',
@@ -91,6 +107,22 @@ describe('Basic queries for faked routes', () => {
           expect.objectContaining({ parcelId: '3818', sheetId: 'SS6828' })
         ])
       )
+    })
+
+    test('Should return 403 for /lms/organisation/{organisationId}/parcel-details/historic/{historicDate} if organisationId is not numeric', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/nonexistent/parcel-details/historic/01-Jan-25'
+      })
+      expect(response.statusCode).toBe(403)
+    })
+
+    test('Should return 403 for /lms/organisation/{organisationId}/parcel-details/historic/{historicDate} if historicDate is invalid', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/parcel-details/historic/invalid'
+      })
+      expect(response.statusCode).toBe(403)
     })
 
     test('Should return data for /lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers with geometries omitted by default', async () => {
@@ -154,6 +186,33 @@ describe('Basic queries for faked routes', () => {
       })
     })
 
+    test('Should return 403 for /lms/organisation/{organisationId}/land-covers if organisationId is not numeric', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/nonexistent/parcel/sheet-id/SS6627/parcel-id/5662/historic/01-Mar-25/land-covers'
+      })
+      expect(response.statusCode).toBe(403)
+    })
+
+    test('Should treat includeGeometries=null as false for land-covers', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/parcel/sheet-id/SS6627/parcel-id/5662/historic/01-Mar-25/land-covers?includeGeometries=null'
+      })
+      expect(response.statusCode).toBe(200)
+      const json = JSON.parse(response.payload)
+      expect(json.features[0].geometry).toBeNull()
+    })
+
+    test('Should treat any unrecognised includeGeometries value as false', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/parcel/sheet-id/SS6627/parcel-id/5662/historic/01-Mar-25/land-covers?includeGeometries=foo'
+      })
+      expect(response.statusCode).toBe(200)
+      expect(JSON.parse(response.payload).features[0].geometry).toBeNull()
+    })
+
     test('Should return data for /lms/organisation/{organisationId}/covers-summary/historic/{historicDate}', async () => {
       const response = await mockServer.inject({
         method: 'GET',
@@ -188,12 +247,20 @@ describe('Basic queries for faked routes', () => {
       expect(response.statusCode).toBe(500)
     })
 
-    test('Should return 400 for /lms/organisation/{organisationId}/covers-summary/historic/{historicDate} if organisationId is not numeric', async () => {
+    test('Should return 403 for /lms/organisation/{organisationId}/covers-summary/historic/{historicDate} if organisationId is not numeric', async () => {
       const response = await mockServer.inject({
         method: 'GET',
         url: '/extapi/lms/organisation/nonexistent/covers-summary/historic/01-Jan-25'
       })
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(403)
+    })
+
+    test('Should return 403 for /lms/organisation/{organisationId}/covers-summary/historic/{historicDate} if historicDate is invalid', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/covers-summary/historic/invalid'
+      })
+      expect(response.statusCode).toBe(403)
     })
 
     test('Should return data for /lms/organisation/{organisationId}/geometries', async () => {
@@ -218,6 +285,14 @@ describe('Basic queries for faked routes', () => {
           })
         ])
       })
+    })
+
+    test('Should return 403 for /lms/organisation/{organisationId}/geometries if organisationId is not numeric', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/nonexistent/geometries?bbox=0,0,0,0'
+      })
+      expect(response.statusCode).toBe(403)
     })
 
     test('Should return 400 for /lms/organisation/{organisationId}/geometries if bbox is missing', async () => {

--- a/test/integration/land-queries.test.js
+++ b/test/integration/land-queries.test.js
@@ -93,10 +93,35 @@ describe('Basic queries for faked routes', () => {
       )
     })
 
-    test('Should return data for /lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers', async () => {
+    test('Should return data for /lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers with geometries omitted by default', async () => {
       const response = await mockServer.inject({
         method: 'GET',
         url: '/extapi/lms/organisation/1111111111/parcel/sheet-id/SS6627/parcel-id/5662/historic/01-Mar-25/land-covers'
+      })
+      expect(response.statusCode).toBe(200)
+      const json = JSON.parse(response.payload)
+      expect(json).toEqual({
+        type: 'FeatureCollection',
+        features: expect.arrayContaining([
+          {
+            id: 11769295,
+            properties: {
+              area: '10270.38',
+              code: '110',
+              name: 'Arable Land',
+              isBpsEligible: 'true'
+            },
+            type: 'Feature',
+            geometry: null
+          }
+        ])
+      })
+    })
+
+    test('Should return data for /lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers with geometries included when requested', async () => {
+      const response = await mockServer.inject({
+        method: 'GET',
+        url: '/extapi/lms/organisation/1111111111/parcel/sheet-id/SS6627/parcel-id/5662/historic/01-Mar-25/land-covers?includeGeometries=true'
       })
       expect(response.statusCode).toBe(200)
       const json = JSON.parse(response.payload)


### PR DESCRIPTION
Addition of endpoint
> GET /lms/organisation/{organisationId}/geometries

Added `includeGeometries` query param to 
> GET /lms/organisation/{organisationId}/geometries

Added `land` schema to contract tests (as it had been missed)

Addresses [FCPDAL-31]

[FCPDAL-31]: https://eaflood.atlassian.net/browse/FCPDAL-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ