### PR TITLE
FCPDAL-434 - user permissions retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+# --- Mock server ---
+# Port the mock listens on (default 3100).
+PORT=3100
+# Pino log level (default 'info').
+#LOG_LEVEL=debug
+
+# --- Contract tests, KITS internal gateway (npm run test:contract:local) ---
+# CDP Platform developer API key.
+CDP_API_KEY=
+# URL of the KITS API to test
+KITS_INTERNAL_URL=https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi
+# Email sent as the auth header (defaults to testuser01@defra.gov.uk).
+#TEST_USER_EMAIL=
+
+# --- Contract tests, KITS EXTERNAL gateway (npm run test:contract:local -- perm) ---
+# Pre-issued Defra Identity token; if unset one is generated with
+# scripts/get-defra-id-token.js, which needs CRN, DEFRA_ID_PASSWORD and the DEFRA_ID_* config.
+DEFRA_ID_TOKEN=
+# URL of the KITS EXTERNAL proxy endpoint.
+KITS_EXTERNAL_URL=https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/external/extapi
+# Customer reference number of the external user under test, sent as the `crn` header;
+# derived from the token's contactId claim when unset (required to generate a token).
+#CRN=
+# An organisation the CRN has a relationship with, used as the example orgId; derived
+# from the token's currentRelationshipId claim when unset.
+#ORG_ID=
+
+# --- Defra Identity OIDC client config (from CDP), for scripts/get-defra-id-token.js ---
+# Only needed when DEFRA_ID_TOKEN is not set; quote any value containing spaces.
+DEFRA_ID_WELL_KNOWN_URL=
+DEFRA_ID_CLIENT_ID=
+DEFRA_ID_CLIENT_SECRET=
+DEFRA_ID_SERVICE_ID=
+DEFRA_ID_POLICY=
+DEFRA_ID_REDIRECT_URL=
+# Password for the CRN under test (the token's user).
+DEFRA_ID_PASSWORD=
+# Required only when the CRN is linked to more than one business.
+#DEFRA_ID_RELATIONSHIP_ID=
+# Set to print token generation stack traces.
+#DEFRA_ID_DEBUG=1
+
+# --- Contract tests, Hitachi payments (test/contract/check-schema.sh pd) ---
+# Client secret for AAD token generation.
+#HITACHI_CLIENT_SECRET=
+# Hitachi API URL override.
+#HITACHI_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/contract/logs/*
 *.key
 *.srl
 .env*
+!.env.example

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,17 +29,17 @@
       "devDependencies": {
         "@redocly/cli": "1.29.0",
         "@vitest/coverage-v8": "4.1.9",
-        "acorn": "8.16.0",
+        "acorn": "^8.16.0",
         "dotenv-cli": "^10.0.0",
         "eslint": "^9.32.0",
         "eslint-plugin-import": "^2.31.0",
         "globals": "^17.7.0",
-        "got": "15.1.0",
+        "got": "^15.1.0",
         "husky": "^9.1.6",
-        "node-html-parser": "9.0.0",
+        "node-html-parser": "^9.0.0",
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3",
-        "tough-cookie": "6.0.2",
+        "tough-cookie": "^6.0.2",
         "vitest": "^4.1.9"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,13 +29,17 @@
       "devDependencies": {
         "@redocly/cli": "1.29.0",
         "@vitest/coverage-v8": "4.1.9",
+        "acorn": "8.16.0",
         "dotenv-cli": "^10.0.0",
         "eslint": "^9.32.0",
         "eslint-plugin-import": "^2.31.0",
         "globals": "^17.7.0",
+        "got": "15.1.0",
         "husky": "^9.1.6",
+        "node-html-parser": "9.0.0",
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3",
+        "tough-cookie": "6.0.2",
         "vitest": "^4.1.9"
       },
       "engines": {
@@ -889,6 +893,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1019,9 +1030,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1330,6 +1341,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1369,6 +1400,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1881,10 +1919,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1903,6 +1948,58 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/byte-counter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+      "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "13.0.19",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
+      "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.2.0",
+        "get-stream": "^9.0.1",
+        "http-cache-semantics": "^4.2.0",
+        "keyv": "^5.6.0",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.1.1",
+        "responselike": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/call-bind": {
@@ -2031,6 +2128,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chunk-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/classnames": {
@@ -2166,6 +2276,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -2176,6 +2303,19 @@
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -2272,6 +2412,22 @@
       "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
       "dev": true
     },
+    "node_modules/decompress-response": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+      "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2348,14 +2504,86 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -2445,6 +2673,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -2998,9 +3239,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -3303,6 +3544,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3397,6 +3655,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^8.0.0",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.18",
+        "chunk-data": "^0.1.0",
+        "decompress-response": "^10.0.0",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.6.0",
+        "lowercase-keys": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^5.6.0",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/handlebars": {
@@ -3577,12 +3872,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http2-client": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
       "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -4010,6 +4326,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -4205,9 +4534,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -4595,6 +4924,19 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -4711,6 +5053,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4804,9 +5159,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4895,6 +5250,17 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-9.0.0.tgz",
+      "integrity": "sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "entities": "^8.0.0"
+      }
+    },
     "node_modules/node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
@@ -4945,9 +5311,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5004,6 +5370,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oas-kit-common": {
@@ -5536,9 +5928,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -5556,7 +5948,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5688,6 +6080,19 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -5928,6 +6333,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5936,6 +6348,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+      "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rolldown": {
@@ -6652,6 +7093,19 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -6705,6 +7159,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6726,6 +7200,19 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -6783,6 +7270,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6877,6 +7380,19 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6904,9 +7420,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,9 +1030,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1927,9 +1927,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3239,9 +3239,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5311,16 +5311,16 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nodemon/node_modules/has-flag": {
@@ -5928,9 +5928,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7420,9 +7420,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -45,17 +45,17 @@
   "devDependencies": {
     "@redocly/cli": "1.29.0",
     "@vitest/coverage-v8": "4.1.9",
-    "acorn": "8.16.0",
+    "acorn": "^8.16.0",
     "dotenv-cli": "^10.0.0",
     "eslint": "^9.32.0",
     "eslint-plugin-import": "^2.31.0",
     "globals": "^17.7.0",
-    "got": "15.1.0",
+    "got": "^15.1.0",
     "husky": "^9.1.6",
-    "node-html-parser": "9.0.0",
+    "node-html-parser": "^9.0.0",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3",
-    "tough-cookie": "6.0.2",
+    "tough-cookie": "^6.0.2",
     "vitest": "^4.1.9"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -45,19 +45,24 @@
   "devDependencies": {
     "@redocly/cli": "1.29.0",
     "@vitest/coverage-v8": "4.1.9",
+    "acorn": "8.16.0",
     "dotenv-cli": "^10.0.0",
     "eslint": "^9.32.0",
     "eslint-plugin-import": "^2.31.0",
     "globals": "^17.7.0",
+    "got": "15.1.0",
     "husky": "^9.1.6",
+    "node-html-parser": "9.0.0",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3",
+    "tough-cookie": "6.0.2",
     "vitest": "^4.1.9"
   },
   "overrides": {
     "js-yaml": "^4.2.0",
     "form-data": "^4.0.6",
-    "dompurify": "^3.4.11"
+    "dompurify": "^3.4.11",
+    "fast-uri": "^3.1.4"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "js-yaml": "^4.2.0",
     "form-data": "^4.0.6",
     "dompurify": "^3.4.11",
-    "fast-uri": "^3.1.4"
+    "fast-uri": "^3.1.5"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/get-defra-id-token.js
+++ b/scripts/get-defra-id-token.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+import * as acorn from 'acorn'
+import got from 'got'
+import { parse as parseHtml } from 'node-html-parser'
+import crypto from 'node:crypto'
+import { CookieJar } from 'tough-cookie'
+
+const UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
+const MAX_ROUNDS = 8
+
+const REQUIRED_CONFIG = {
+  crn: 'CRN',
+  password: 'DEFRA_ID_PASSWORD',
+  wellKnownUrl: 'DEFRA_ID_WELL_KNOWN_URL',
+  clientId: 'DEFRA_ID_CLIENT_ID',
+  clientSecret: 'DEFRA_ID_CLIENT_SECRET',
+  serviceId: 'DEFRA_ID_SERVICE_ID',
+  policy: 'DEFRA_ID_POLICY',
+  redirectUrl: 'DEFRA_ID_REDIRECT_URL'
+}
+const OPTIONAL_CONFIG = { relationshipId: 'DEFRA_ID_RELATIONSHIP_ID' }
+
+const readConfig = () => {
+  const config = Object.fromEntries(
+    Object.entries({ ...REQUIRED_CONFIG, ...OPTIONAL_CONFIG }).map(([key, envVar]) => [
+      key,
+      process.env[envVar]
+    ])
+  )
+  const missing = Object.entries(REQUIRED_CONFIG)
+    .filter(([key]) => !config[key])
+    .map(([, envVar]) => envVar)
+  if (missing.length) {
+    throw new Error(`Missing required config: ${missing.join(', ')}`)
+  }
+  return { ...config, scope: `openid offline_access ${config.clientId}` }
+}
+
+const cookieJar = new CookieJar()
+const http = got.extend({
+  cookieJar,
+  methodRewriting: true,
+  throwHttpErrors: false,
+  maxRedirects: 20,
+  retry: { limit: 0 },
+  headers: {
+    'user-agent': UA,
+    accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+  }
+})
+
+const tryJson = (body) => {
+  try {
+    return JSON.parse(body)
+  } catch {
+    return {}
+  }
+}
+
+const parseSettings = (html) => {
+  const script = parseHtml(html)
+    .querySelectorAll('script')
+    .find((el) => el.rawText.includes('var SETTINGS = {'))
+  if (!script) return null
+  let settings
+  try {
+    const declaration = acorn
+      .parse(script.rawText, { ecmaVersion: 'latest' })
+      .body.filter((node) => node.type === 'VariableDeclaration')
+      .flatMap((node) => node.declarations)
+      .find((node) => node.id.name === 'SETTINGS')
+    settings = JSON.parse(script.rawText.slice(declaration.init.start, declaration.init.end))
+  } catch {
+    return null
+  }
+  return {
+    csrf: settings.csrf ?? null,
+    transId: settings.transId ?? null,
+    api: settings.api ?? null,
+    tenant: settings.hosts?.tenant ?? null,
+    policy: settings.hosts?.policy ?? null
+  }
+}
+
+const parseFieldIds = (html) =>
+  [...html.matchAll(/"ID"\s*:\s*"([^"]*)"/g)].map((m) => m[1]).filter(Boolean)
+
+const discoverEndpoints = async (wellKnownUrl) => {
+  const oidc = await http(wellKnownUrl, { headers: { accept: 'application/json' } }).json()
+  return {
+    authorizeEndpoint: oidc.authorization_endpoint,
+    tokenEndpoint: oidc.token_endpoint,
+    b2cBase: new URL(oidc.authorization_endpoint).origin
+  }
+}
+
+const passFrontDoor = async (authorizeEndpoint, b2cBase, config) => {
+  const state = crypto.randomUUID()
+  const authorizeUrl =
+    authorizeEndpoint +
+    '?' +
+    new URLSearchParams({
+      client_id: config.clientId,
+      response_type: 'code',
+      redirect_uri: config.redirectUrl,
+      scope: config.scope,
+      response_mode: 'query',
+      state,
+      nonce: crypto.randomUUID(),
+      serviceId: config.serviceId,
+      p: config.policy
+    })
+  const gatePage = await http.get(authorizeUrl)
+  const crumb = parseHtml(gatePage.body).querySelector('input[name="crumb"]')?.getAttribute('value')
+  if (!crumb) throw new Error('Did not reach the idphub check-js page (unexpected journey).')
+
+  const checkJsUrl = new URL('/registration/journey/check-js/check-js-enabled', gatePage.url).href
+  const resumePage = await http.post(checkJsUrl, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Referer: checkJsUrl },
+    body: new URLSearchParams({ crumb, checkJs: '' }).toString()
+  })
+  const callbackForm = parseHtml(resumePage.body).querySelector('form[action*="authresp"]')
+  const callbackAction = callbackForm?.getAttribute('action')
+  const cbCode = callbackForm?.querySelector('input[name="code"]')?.getAttribute('value')
+  const cbState = callbackForm?.querySelector('input[name="state"]')?.getAttribute('value')
+  if (!callbackAction || !cbCode)
+    throw new Error('idphub did not return a callback code (check-js gate failed).')
+
+  const page = await http.post(callbackAction, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Referer: `${b2cBase}/` },
+    body: new URLSearchParams({ code: cbCode, state: cbState }).toString()
+  })
+  return { page, state }
+}
+
+const completeSelfAssertedRounds = async (startPage, b2cBase, config) => {
+  let page = startPage
+  const redirectOrigin = new URL(config.redirectUrl).origin
+  const appRedirect = (response) => {
+    const location = response.headers.location
+    if (!location) return null
+    const next = new URL(location, response.url)
+    return next.href.startsWith(redirectOrigin) ? next : null
+  }
+
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    const settings = parseSettings(page.body)
+    if (!settings || !settings.csrf || !settings.transId) {
+      throw new Error(
+        `Expected a B2C SelfAsserted page but found none (round ${round}). ` +
+          (/error/i.test(page.body)
+            ? 'The page mentions an error — check credentials.'
+            : 'Journey may have changed.')
+      )
+    }
+    const fields = parseFieldIds(page.body)
+    const body = new URLSearchParams({ request_type: 'RESPONSE' })
+    if (fields.includes('crn')) {
+      body.set('crn', config.crn)
+      body.set('password', config.password)
+    } else if (fields.includes('currentRelationshipId')) {
+      if (!config.relationshipId) {
+        throw new Error(
+          'This account has multiple businesses and pure-HTTP cannot list them\n' +
+            '(they are rendered client-side from a "picker" resource).\n' +
+            'Re-run with DEFRA_ID_RELATIONSHIP_ID set.'
+        )
+      }
+      body.set('currentRelationshipId', config.relationshipId)
+    } else {
+      for (const field of fields) body.set(field, '')
+    }
+
+    const saUrl = `${b2cBase}${settings.tenant}/SelfAsserted?tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`
+    const saRes = await http.post(saUrl, {
+      followRedirect: false,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        'X-CSRF-TOKEN': settings.csrf,
+        'X-Requested-With': 'XMLHttpRequest',
+        Referer: `${b2cBase}${settings.tenant}/`
+      },
+      body: body.toString()
+    })
+    const saJson = tryJson(saRes.body)
+    if (!saRes.ok || (saJson.status && String(saJson.status) !== '200')) {
+      throw new Error(
+        `B2C rejected the step (HTTP ${saRes.statusCode}, status ${saJson.status ?? 'none'}): ` +
+          (saJson.message || saRes.body.slice(0, 200))
+      )
+    }
+
+    const confirmedUrl = `${b2cBase}${settings.tenant}/api/${settings.api}/confirmed?rememberMe=false&csrf_token=${settings.csrf}&tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`
+    const confirmed = await http.get(confirmedUrl, {
+      followRedirect: (response) => !appRedirect(response)
+    })
+    const redirectToApp = appRedirect(confirmed)
+    if (!redirectToApp) {
+      page = confirmed
+      continue
+    }
+
+    const err = redirectToApp.searchParams.get('error')
+    if (err) {
+      throw new Error(
+        `Defra Identity returned error: ${err} - ${redirectToApp.searchParams.get('error_description') || ''}`
+      )
+    }
+    const code = redirectToApp.searchParams.get('code')
+    if (!code) {
+      throw new Error(
+        `Redirected to ${config.redirectUrl} with neither a code nor an error (unexpected journey).`
+      )
+    }
+    return { code, state: redirectToApp.searchParams.get('state') }
+  }
+
+  throw new Error(`Completed ${MAX_ROUNDS} journey rounds without a redirect back to the app.`)
+}
+
+const redeemCode = async (tokenEndpoint, code, config) => {
+  const tokenRes = await http.post(tokenEndpoint, {
+    followRedirect: false,
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: config.redirectUrl,
+      scope: config.scope
+    }).toString()
+  })
+  const token = tryJson(tokenRes.body)
+  if (!tokenRes.ok || token.error) {
+    throw new Error(
+      `Token endpoint failed: HTTP ${tokenRes.statusCode}\n${token.error || ''}: ${(token.error_description || '').split(/\r?\n/)[0]}`
+    )
+  }
+
+  return token.access_token || token.id_token
+}
+
+const main = async () => {
+  const config = readConfig()
+  const { authorizeEndpoint, tokenEndpoint, b2cBase } = await discoverEndpoints(config.wellKnownUrl)
+  const { page, state } = await passFrontDoor(authorizeEndpoint, b2cBase, config)
+  const captured = await completeSelfAssertedRounds(page, b2cBase, config)
+  if (captured.state && captured.state !== state)
+    throw new Error('State mismatch on redirect (possible CSRF).')
+
+  console.log(await redeemCode(tokenEndpoint, captured.code, config))
+}
+
+main().catch((err) => {
+  console.error(process.env.DEFRA_ID_DEBUG ? err : err.message)
+  process.exitCode = 1
+})

--- a/src/factories/common.js
+++ b/src/factories/common.js
@@ -6,15 +6,20 @@ export const faker = fakerEN_GB
 // https://fakerjs.dev/api/faker#setdefaultrefdate:~:text=faker.setDefaultRefDate()%3A%20For%20generating%20reproducible%20dates.
 faker.setDefaultRefDate(new Date('2025-01-01'))
 
-const intOrValue = (value) => {
+// faker.seed only accepts numbers, so non-numeric seeds (e.g. permission
+// function names) are hashed to a stable integer.
+const hashString = (str) =>
+  [...str].reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) % 2147483647, 7)
+
+const intOrHash = (value) => {
   const integer = Number.parseInt(value, 10)
-  return Number.isNaN(integer) ? value : integer
+  return Number.isNaN(integer) ? hashString(`${value}`) : integer
 }
 export const safeSeed = (seed) => {
   if (Array.isArray(seed)) {
-    return faker.seed(seed.map((s) => intOrValue(s)))
+    return faker.seed(seed.map((s) => intOrHash(s)))
   }
-  return faker.seed(intOrValue(seed))
+  return faker.seed(intOrHash(seed))
 }
 
 export const fakeAddress = (overrides = {}) => ({

--- a/src/factories/siti-agri/permissions.factory.js
+++ b/src/factories/siti-agri/permissions.factory.js
@@ -1,0 +1,56 @@
+import { faker, safeSeed } from '../common.js'
+
+// The external-user function names the upstream recognises - mirrors AuthorisationData in
+// src/routes/kits-v1/permissions-schema.oas.yml (a unit test keeps the two in sync).
+export const KNOWN_FUNCTIONS = [
+  'addOrRemoveOrTransferLand',
+  'addRoleOrPrivilege',
+  'amendApplication',
+  'amendBankAccountDetails',
+  'amendBusinessDetails',
+  'amendControlledBusinessInfo',
+  'amendELMApplications',
+  'amendEntitlements',
+  'amendLegallyResponsiblePeople',
+  'amendNewYoungFarmerProcess',
+  'applyForBPS',
+  'closeBusiness',
+  'confirmBusiness',
+  'deleteBusiness',
+  'modifyRoleOrPrivilege',
+  'removeRoleOrPrivilege',
+  'submitApplication',
+  'submitELMApplications',
+  'updateLandUse',
+  'viewApplication',
+  'viewBusinessBankAccount',
+  'viewBusinessDetails',
+  'viewCPH',
+  'viewCSAgreements',
+  'viewCSApplications',
+  'viewCSClaims',
+  'viewCountrysideStewardship',
+  'viewELMApplications',
+  'viewEntitlements',
+  'viewLand',
+  'viewLegallyResponsiblePeople'
+]
+
+const knownFunctions = new Set(KNOWN_FUNCTIONS)
+
+const hashFunctionName = (name) =>
+  [...name].reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) % 2147483647, 7)
+
+export const retrieveAuthorisationByFunction = (orgId, functions) => {
+  return functions.reduce((data, functionName) => {
+    // The upstream echoes unrecognised function names back with a false.
+    if (!knownFunctions.has(functionName)) {
+      data[functionName] = false
+      return data
+    }
+    // Seed per org+function so a function's flag is stable regardless of what else is requested.
+    safeSeed([orgId, hashFunctionName(functionName)])
+    data[functionName] = faker.datatype.boolean()
+    return data
+  }, {})
+}

--- a/src/factories/siti-agri/permissions.factory.js
+++ b/src/factories/siti-agri/permissions.factory.js
@@ -38,9 +38,6 @@ export const KNOWN_FUNCTIONS = [
 
 const knownFunctions = new Set(KNOWN_FUNCTIONS)
 
-const hashFunctionName = (name) =>
-  [...name].reduce((hash, char) => (hash * 31 + char.charCodeAt(0)) % 2147483647, 7)
-
 export const retrieveAuthorisationByFunction = (orgId, functions) => {
   return functions.reduce((data, functionName) => {
     // The upstream echoes unrecognised function names back with a false.
@@ -49,7 +46,7 @@ export const retrieveAuthorisationByFunction = (orgId, functions) => {
       return data
     }
     // Seed per org+function so a function's flag is stable regardless of what else is requested.
-    safeSeed([orgId, hashFunctionName(functionName)])
+    safeSeed([orgId, functionName])
     data[functionName] = faker.datatype.boolean()
     return data
   }, {})

--- a/src/plugins/kits-v1-router.js
+++ b/src/plugins/kits-v1-router.js
@@ -3,6 +3,7 @@ import { bank } from '../routes/kits-v1/bank.js'
 import { land } from '../routes/kits-v1/land.js'
 import { notifications } from '../routes/kits-v1/messages.js'
 import { organisation } from '../routes/kits-v1/organisation.js'
+import { permissions } from '../routes/kits-v1/permissions.js'
 import { person } from '../routes/kits-v1/person.js'
 import { sitiagri } from '../routes/kits-v1/siti-agri.js'
 import { referenceData } from '../routes/kits-v1/reference-data.js'
@@ -16,6 +17,7 @@ const router = {
         ...organisation,
         ...authenticate,
         ...sitiagri,
+        ...permissions,
         ...notifications,
         ...land,
         ...bank,

--- a/src/plugins/schemata.js
+++ b/src/plugins/schemata.js
@@ -39,6 +39,13 @@ export const schemata = {
         },
         {
           method: 'GET',
+          path: '/schemata/permissions.yml',
+          handler: {
+            file: path.join(__dirname, '../routes/kits-v1/permissions-schema.oas.yml')
+          }
+        },
+        {
+          method: 'GET',
           path: '/schemata/land.yml',
           handler: {
             file: path.join(__dirname, '../routes/kits-v1/land-schema.oas.yml')

--- a/src/routes/kits-v1/permissions-schema.oas.yml
+++ b/src/routes/kits-v1/permissions-schema.oas.yml
@@ -161,10 +161,51 @@ components:
                 </body></html>
 
   schemas:
-    ResponseWrapper:
+    AuthorisationByFunctionResponse:
       type: object
       properties:
-        data: {} # left abstract, to be overridden in specific responses
+        data:
+          type: object
+          description: >
+            A map of requested function name to a boolean indicating whether the external user is
+            authorised to perform it. Only the functions requested via `byFunction` are returned,
+            so every property is optional. The recognised external-user functions are listed
+            below.
+          properties:
+            addOrRemoveOrTransferLand: { type: boolean }
+            addRoleOrPrivilege: { type: boolean }
+            amendApplication: { type: boolean }
+            amendBankAccountDetails: { type: boolean }
+            amendBusinessDetails: { type: boolean }
+            amendControlledBusinessInfo: { type: boolean }
+            amendELMApplications: { type: boolean }
+            amendEntitlements: { type: boolean }
+            amendLegallyResponsiblePeople: { type: boolean }
+            amendNewYoungFarmerProcess: { type: boolean }
+            applyForBPS: { type: boolean }
+            closeBusiness: { type: boolean }
+            confirmBusiness: { type: boolean }
+            deleteBusiness: { type: boolean }
+            modifyRoleOrPrivilege: { type: boolean }
+            removeRoleOrPrivilege: { type: boolean }
+            submitApplication: { type: boolean }
+            submitELMApplications: { type: boolean }
+            updateLandUse: { type: boolean }
+            viewApplication: { type: boolean }
+            viewBusinessBankAccount: { type: boolean }
+            viewBusinessDetails: { type: boolean }
+            viewCPH: { type: boolean }
+            viewCSAgreements: { type: boolean }
+            viewCSApplications: { type: boolean }
+            viewCSClaims: { type: boolean }
+            viewCountrysideStewardship: { type: boolean }
+            viewELMApplications: { type: boolean }
+            viewEntitlements: { type: boolean }
+            viewLand: { type: boolean }
+            viewLegallyResponsiblePeople: { type: boolean }
+          # the pipe-separated list is caller-supplied, so unrecognised functions may be echoed back
+          additionalProperties:
+            type: boolean
         errorString:
           type: [string, 'null']
         success:
@@ -174,66 +215,23 @@ components:
         - errorString
         - success
       additionalProperties: false
-    AuthorisationByFunctionResponse:
-      allOf:
-        - $ref: '#/components/schemas/ResponseWrapper'
-        - type: object
-          properties:
-            data:
-              $ref: '#/components/schemas/AuthorisationData'
     ErrorResponse:
       description: >
         The service's JSON error envelope - the same wrapper as a success response, but with
         `data` nulled, `success` false and the reason in `errorString`.
-      allOf:
-        - $ref: '#/components/schemas/ResponseWrapper'
-        - type: object
-          properties:
-            data:
-              type: 'null'
-            errorString:
-              type: string
-    AuthorisationData:
       type: object
-      description: >
-        A map of requested function name to a boolean indicating whether the external user is
-        authorised to perform it. Only the functions requested via `byFunction` are returned, so
-        every property is optional. The recognised external-user functions are listed below.
       properties:
-        addOrRemoveOrTransferLand: { type: boolean }
-        addRoleOrPrivilege: { type: boolean }
-        amendApplication: { type: boolean }
-        amendBankAccountDetails: { type: boolean }
-        amendBusinessDetails: { type: boolean }
-        amendControlledBusinessInfo: { type: boolean }
-        amendELMApplications: { type: boolean }
-        amendEntitlements: { type: boolean }
-        amendLegallyResponsiblePeople: { type: boolean }
-        amendNewYoungFarmerProcess: { type: boolean }
-        applyForBPS: { type: boolean }
-        closeBusiness: { type: boolean }
-        confirmBusiness: { type: boolean }
-        deleteBusiness: { type: boolean }
-        modifyRoleOrPrivilege: { type: boolean }
-        removeRoleOrPrivilege: { type: boolean }
-        submitApplication: { type: boolean }
-        submitELMApplications: { type: boolean }
-        updateLandUse: { type: boolean }
-        viewApplication: { type: boolean }
-        viewBusinessBankAccount: { type: boolean }
-        viewBusinessDetails: { type: boolean }
-        viewCPH: { type: boolean }
-        viewCSAgreements: { type: boolean }
-        viewCSApplications: { type: boolean }
-        viewCSClaims: { type: boolean }
-        viewCountrysideStewardship: { type: boolean }
-        viewELMApplications: { type: boolean }
-        viewEntitlements: { type: boolean }
-        viewLand: { type: boolean }
-        viewLegallyResponsiblePeople: { type: boolean }
-      # the pipe-separated list is caller-supplied, so unrecognised functions may be echoed back
-      additionalProperties:
-        type: boolean
+        data:
+          type: 'null'
+        errorString:
+          type: string
+        success:
+          type: boolean
+      required:
+        - data
+        - errorString
+        - success
+      additionalProperties: false
 
   securitySchemes:
     mTLS:

--- a/src/routes/kits-v1/permissions-schema.oas.yml
+++ b/src/routes/kits-v1/permissions-schema.oas.yml
@@ -1,0 +1,242 @@
+openapi: 3.1.0
+info:
+  title: SitiAgri Authorisation (Permissions) API
+  description: >
+    API for retrieving the operations (functions) an external user is authorised to perform for a
+    particular business. Consumers use the response to show/hide functionality in their UI.
+    NOTE: DAL does not enforce these permissions - the upstream systems do.
+  version: '1.0.0'
+  license:
+    name: 'Open Government Licence v3.0'
+    url: 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3'
+security:
+  - mTLS: []
+servers:
+  - url: 'https://chs-upgrade-api.ruraldev.org.uk:8446/extapi'
+    description: 'The test server for KITS/V1 APIs'
+tags:
+  - name: 'authorisation'
+    description: 'Operations related to external user authorisation'
+paths:
+  /SitiAgriApi/authorisation/organisation/{orgId}/byFunction:
+    get:
+      tags:
+        - 'authorisation'
+        - 'permissions'
+      summary: 'Get authorised functions for an external user for a business.'
+      description: >
+        Returns, for each requested function, whether the external user is authorised to perform it
+        for the specified organisation. The consuming service supplies the pipe-separated list of
+        functions it is interested in via the `functions` query parameter, e.g.
+        `.../organisation/{orgId}/byFunction?functions=viewLand|amendBusinessDetails&module=CUST_SS_PORTAL&timestamp=1720000000000`.
+      operationId: 'getAuthorisationByFunction'
+      parameters:
+        - name: 'orgId'
+          in: 'path'
+          description: 'Organisation id the external user is acting on behalf of.'
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            examples:
+              - 5583781
+              - 5849659
+              - 5852711
+        - name: 'functions'
+          in: 'query'
+          description: >
+            Pipe-separated list of the functions to return an authorisation flag for. The upstream
+            does not validate the value - any unrecognised (or empty) function name is simply
+            echoed back with a `false` flag.
+          required: true
+          schema:
+            type: string
+            examples:
+              - 'viewLand|amendBusinessDetails'
+              - 'viewApplication|viewEntitlements|amendEntitlements'
+        - name: 'module'
+          in: 'query'
+          description: >
+            The consuming module; `CUST_SS_PORTAL` for the self-service portal. The upstream does
+            not validate the value - an unrecognised module simply returns `false` for every
+            requested function.
+          required: true
+          schema:
+            type: string
+            examples:
+              - 'CUST_SS_PORTAL'
+        - name: 'timestamp'
+          in: 'query'
+          description: >
+            Request timestamp as epoch milliseconds. Callers are expected to supply it, but the
+            upstream does not require (or validate) it.
+          required: false
+          schema:
+            type: string
+            examples:
+              - '1720000000000'
+      responses:
+        '200':
+          description: Returns the requested functions mapped to their authorised boolean.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthorisationByFunctionResponse'
+        '400':
+          description: >
+            The request was rejected before reaching the service, e.g. by the upstream WAF
+            (typically as an empty-bodied 400).
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          description: >
+            Getting authorisation data is forbidden, or a WAF rule has been triggered, or the orgId
+            was not a valid integer (i.e. 404!). When the authenticated user has no relationship
+            with the requested orgId, the service responds with a JSON error envelope
+            (e.g. errorString "Parent user id not found").
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          description: >
+            Returned by the service (as its JSON error envelope, errorString "An error has
+            occurred.") whenever the `functions` or `module` query parameter is omitted - the
+            upstream 500s instead of returning a proper 400 for these bad requests. This is the
+            only known trigger; all other malformed input is accepted with a 200 (see the
+            parameter descriptions) or rejected with a 403 (bad `orgId`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  responses:
+    BadRequest:
+      description: Bad Request response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                example: 400
+              message:
+                type: string
+                example: 'HTTP 400 Bad Request'
+        text/plain:
+          schema:
+            type: string
+            example: ''
+        text/html:
+          schema:
+            type: string
+          examples:
+            badRequest:
+              summary: Bad Request HTML response
+              value: |
+                <html><body><h1>400 Bad request</h1>
+                Your browser sent an invalid request.
+                </body></html>
+    Forbidden:
+      description: Forbidden response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            noRelationship:
+              summary: The user has no relationship with the requested organisation
+              value:
+                data: null
+                success: false
+                errorString: 'Parent user id not found'
+        text/html:
+          schema:
+            type: string
+          examples:
+            forbidden:
+              summary: Forbidden HTML response
+              value: |
+                <html><body><h1>403 Forbidden</h1>
+                Request forbidden by administrative rules.
+                </body></html>
+
+  schemas:
+    ResponseWrapper:
+      type: object
+      properties:
+        data: {} # left abstract, to be overridden in specific responses
+        errorString:
+          type: [string, 'null']
+        success:
+          type: boolean
+      required:
+        - data
+        - errorString
+        - success
+      additionalProperties: false
+    AuthorisationByFunctionResponse:
+      allOf:
+        - $ref: '#/components/schemas/ResponseWrapper'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/AuthorisationData'
+    ErrorResponse:
+      description: >
+        The service's JSON error envelope - the same wrapper as a success response, but with
+        `data` nulled, `success` false and the reason in `errorString`.
+      allOf:
+        - $ref: '#/components/schemas/ResponseWrapper'
+        - type: object
+          properties:
+            data:
+              type: 'null'
+            errorString:
+              type: string
+    AuthorisationData:
+      type: object
+      description: >
+        A map of requested function name to a boolean indicating whether the external user is
+        authorised to perform it. Only the functions requested via `byFunction` are returned, so
+        every property is optional. The recognised external-user functions are listed below.
+      properties:
+        addOrRemoveOrTransferLand: { type: boolean }
+        addRoleOrPrivilege: { type: boolean }
+        amendApplication: { type: boolean }
+        amendBankAccountDetails: { type: boolean }
+        amendBusinessDetails: { type: boolean }
+        amendControlledBusinessInfo: { type: boolean }
+        amendELMApplications: { type: boolean }
+        amendEntitlements: { type: boolean }
+        amendLegallyResponsiblePeople: { type: boolean }
+        amendNewYoungFarmerProcess: { type: boolean }
+        applyForBPS: { type: boolean }
+        closeBusiness: { type: boolean }
+        confirmBusiness: { type: boolean }
+        deleteBusiness: { type: boolean }
+        modifyRoleOrPrivilege: { type: boolean }
+        removeRoleOrPrivilege: { type: boolean }
+        submitApplication: { type: boolean }
+        submitELMApplications: { type: boolean }
+        updateLandUse: { type: boolean }
+        viewApplication: { type: boolean }
+        viewBusinessBankAccount: { type: boolean }
+        viewBusinessDetails: { type: boolean }
+        viewCPH: { type: boolean }
+        viewCSAgreements: { type: boolean }
+        viewCSApplications: { type: boolean }
+        viewCSClaims: { type: boolean }
+        viewCountrysideStewardship: { type: boolean }
+        viewELMApplications: { type: boolean }
+        viewEntitlements: { type: boolean }
+        viewLand: { type: boolean }
+        viewLegallyResponsiblePeople: { type: boolean }
+      # the pipe-separated list is caller-supplied, so unrecognised functions may be echoed back
+      additionalProperties:
+        type: boolean
+
+  securitySchemes:
+    mTLS:
+      type: mutualTLS
+      description: >
+        Mutual TLS authentication. Client must present a certificate issued by the server.

--- a/src/routes/kits-v1/permissions.js
+++ b/src/routes/kits-v1/permissions.js
@@ -3,11 +3,6 @@ import { checkId } from '../../utils/shared-datatypes.js'
 
 const responseWrapper = { errorString: null, success: true }
 
-const wafForbiddenHtml = `<html><body><h1>403 Forbidden</h1>
-Request forbidden by administrative rules.
-</body></html>
-`
-
 const errorEnvelope = { data: null, success: false, errorString: 'An error has occurred.' }
 
 // Splits the pipe-separated list the way the upstream does
@@ -23,12 +18,7 @@ export const permissions = [
     method: 'GET',
     path: '/SitiAgriApi/authorisation/organisation/{orgId}/byFunction',
     handler: async (request, h) => {
-      let orgId
-      try {
-        orgId = checkId(request, 'orgId')
-      } catch {
-        return h.response(wafForbiddenHtml).code(403).type('text/html')
-      }
+      const orgId = checkId(request, 'orgId')
 
       let { functions, module } = request.query
       if (functions === undefined || module === undefined) {

--- a/src/routes/kits-v1/permissions.js
+++ b/src/routes/kits-v1/permissions.js
@@ -1,0 +1,50 @@
+import { retrieveAuthorisationByFunction } from '../../factories/siti-agri/permissions.factory.js'
+import { checkId } from '../../utils/shared-datatypes.js'
+
+const responseWrapper = { errorString: null, success: true }
+
+const wafForbiddenHtml = `<html><body><h1>403 Forbidden</h1>
+Request forbidden by administrative rules.
+</body></html>
+`
+
+const errorEnvelope = { data: null, success: false, errorString: 'An error has occurred.' }
+
+// Splits the pipe-separated list the way the upstream does
+export const parseRequestedFunctions = (functions) => {
+  if (functions === '') return ['']
+  const tokens = functions.split('|')
+  while (tokens.length && tokens.at(-1) === '') tokens.pop()
+  return tokens
+}
+
+export const permissions = [
+  {
+    method: 'GET',
+    path: '/SitiAgriApi/authorisation/organisation/{orgId}/byFunction',
+    handler: async (request, h) => {
+      let orgId
+      try {
+        orgId = checkId(request, 'orgId')
+      } catch {
+        return h.response(wafForbiddenHtml).code(403).type('text/html')
+      }
+
+      let { functions, module } = request.query
+      if (functions === undefined || module === undefined) {
+        return h.response(errorEnvelope).code(500)
+      }
+      if (Array.isArray(functions)) functions = functions.at(-1)
+      if (Array.isArray(module)) module = module.at(-1)
+
+      const requested = parseRequestedFunctions(functions)
+      // an unrecognised module returns `false` for everything
+      const data =
+        module.toUpperCase() === 'CUST_SS_PORTAL'
+          ? retrieveAuthorisationByFunction(orgId, requested)
+          : Object.fromEntries(requested.map((functionName) => [functionName, false]))
+
+      return h.response({ ...responseWrapper, data })
+    }
+  }
+]

--- a/test/contract/README.md
+++ b/test/contract/README.md
@@ -25,7 +25,7 @@ test/contract/check-schema.sh help
 
 ```shell
 export CDP_API_KEY=[KEY GENERATED ABOVE]
-export KITS_URL=https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi
+export KITS_INTERNAL_URL=https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi
 test/contract/check-schema.sh person
 ```
 

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -10,10 +10,10 @@ mkdir -p ./tmp
 usage() {
   set +x
   echo
-  echo "Run schemathesis contract tests against the upstream KITS."
+  echo "Run schemathesis contract tests against the upstream KITS (internal or external gateway) or Hitachi."
   echo "All tests are run against the 'upgrade' API env."
   echo
-  echo "Usage: $0 {a|auth|authenticate|b|bank|o|org|organisation|p|person|r|rd|reference-data|s|sa|siti-agri|help}"
+  echo "Usage: $0 {a|auth|authenticate|b|bank|l|land|o|org|organisation|p|person|perm|permissions|r|rd|reference-data|pd|payments|s|sa|siti-agri|help}"
   echo
   echo "Where the argument specifies which schema to test:"
   echo "  a  | auth | authenticate - test the Authenticate schema"
@@ -21,6 +21,7 @@ usage() {
   echo "  l  | land                - test the Land schema"
   echo "  o  | org | organisation  - test the Organisation schema"
   echo "  p  | person              - test the Person schema"
+  echo "  perm | permissions       - test the Authorisation (Permissions) schema (KITS EXTERNAL gateway)"
   echo "  r  | rd | reference-data - test the Reference Data schema"
   echo "  pd | payments            - test the Payment Details schema"
   echo "  s  | sa | siti-agri      - test the Siti-Agri schema"
@@ -28,19 +29,58 @@ usage() {
   echo
   echo "NOTE: additionally the following environment variables must be set:"
   echo "  CDP_API_KEY - CDP Platform developer API key "
-  echo "  KITS_URL  - the URL of the KITS API to use (this should be the DAL Mock proxy endpoint, via the ephemeral endpoint)"
+  echo "  KITS_INTERNAL_URL  - the URL of the KITS API to use (this should be the DAL Mock proxy endpoint, via the ephemeral endpoint)"
+  echo "  CDP_API_KEY    - CDP Platform developer API key"
+  echo "  DEFRA_ID_TOKEN - a pre-issued Defra Identity token; if unset one is generated"
+  echo "                   with scripts/get-defra-id-token.js, which needs CRN,"
+  echo "                   DEFRA_ID_PASSWORD and the DEFRA_ID_* client config (see .env.example)"
+  echo "  KITS_EXTERNAL_URL - the URL of the KITS EXTERNAL proxy endpoint (defaults to"
+  echo "                      the deployed mock's /proxy/external/extapi ephemeral route)"
   echo "or..."
   echo "  HITACHI_CLIENT_SECRET - the client secret for token generation"
 }
 
+cleanup() {
+  local status=$?
+  if [ ${status} -ne 0 ] && [ -f "${baseDir}/tmp/vcr.yaml" ]; then
+    echo "NOTE: report from the failed run left at ${baseDir}/tmp/vcr.yaml" 1>&2
+    return
+  fi
+  rm -rf "${baseDir}/tmp"
+}
+trap cleanup EXIT
+
+# Resolve the Defra ID token (generating one if needed) and default CRN/ORG_ID from
+# its claims.
+resolve_defra_id_token() {
+  if [ -z "${DEFRA_ID_TOKEN}" ]; then
+    if [ -z "${CRN}" ]; then
+      echo "ERROR: CRN (plus DEFRA_ID_PASSWORD and the DEFRA_ID_* config) must be set to generate a Defra Identity token" 1>&2
+      usage
+      exit 1
+    fi
+    echo "Generating a Defra Identity token for the external gateway..."
+    DEFRA_ID_TOKEN=$( node "${rootDir}/scripts/get-defra-id-token.js" )
+    if [ -z "${DEFRA_ID_TOKEN}" ]; then
+      echo "ERROR: DEFRA_ID_TOKEN was not generated correctly" 1>&2
+      usage
+      exit 1
+    fi
+  fi
+  claim() {
+    node -p 'JSON.parse(Buffer.from(process.argv[2].split(".")[1], "base64url").toString())[process.argv[1]] ?? ""' "$1" "${DEFRA_ID_TOKEN}"
+  }
+  CRN="${CRN:-$( claim contactId )}"
+  ORG_ID="${ORG_ID:-$( claim currentRelationshipId )}"
+}
+
 # check OPTION argument
-kits=false
 case "$1" in
   h | help | --help | -h )
     usage
     exit 0
     ;;
-  # KITS APIs
+  # KITS APIs (internal gateway)
   b | bank )
     schema="kits-v1/bank"
     mutations='. |
@@ -58,13 +98,13 @@ case "$1" in
 .paths["/bank-change-service/v1/locked-status/{organisationId}/{personId}"].get.parameters[1].schema.examples = ["5020949"] |
 .paths["/bank-change-service/v1/account-status/{organisationId}"].get.parameters[0].schema.examples = ["5583781"] |
 .paths["/bank-change-service/v1/existing-accounts/{frn}"].get.parameters[0].schema.examples = ["10014489653"]'
-    kits=true
+    gateway="kits-internal"
     ;;
   a | auth | authenticate )
     schema="kits-v1/authenticate"
     mutations='. |
 .paths["/external-auth/security-answers/{crn}"].get.parameters[0].schema.examples = [1105739979,1106046692,1106077237,1100932879,1105430162]'
-    kits=true
+    gateway="kits-internal"
     ;;
   l | land )
     schema="kits-v1/land"
@@ -74,7 +114,7 @@ case "$1" in
 .components.parameters.parcelId.schema.examples = ["3227"] |
 .components.parameters.historicDate.schema.examples = ["19-Jul-24"] |
 .paths["/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"].get.parameters[4].schema.examples = [true, false]'
-    kits=true
+    gateway="kits-internal"
     ;;
   o | org | organisation )
     schema="kits-v1/organisation"
@@ -87,7 +127,7 @@ case "$1" in
 .components.schemas.SearchRequestBody.examples[4].primarySearchPhrase = "YO18 8RL" |
 .paths["/organisation/{organisationId}/lock"].post.parameters[0].schema.examples = [5583781,5849659,5852711,5858233] |
 .paths["/organisation/{organisationId}/unlock"].post.parameters[0].schema.examples = [5583781,5849659,5852711,5858233]'
-    kits=true
+    gateway="kits-internal"
     ;;
   p | person )
     schema="kits-v1/person"
@@ -101,12 +141,12 @@ case "$1" in
 .components.schemas.SearchRequestBody.examples[5].primarySearchPhrase = "EX14 2XA" |
 .components.schemas.SearchRequestBody.examples[6].primarySearchPhrase = "123456" |
 .components.schemas.SearchRequestBody.examples[7].primarySearchPhrase = "123456"'
-    kits=true
+    gateway="kits-internal"
     ;;
   r | rd | reference-data )
     schema="kits-v1/reference-data"
     mutations='.'
-    kits=true
+    gateway="kits-internal"
     ;;
   s | sa | siti-agri )
     schema="kits-v1/siti-agri"
@@ -117,13 +157,22 @@ case "$1" in
 .paths["/SitiAgriApi/cv/landUseByBusinessParcel/sheet/{sheet}/parcel/{parcel}/sbi/{sbi}/list"].get.parameters[0].schema.examples = ["SS6528","S60869","S15653"] |
 .paths["/SitiAgriApi/cv/landUseByBusinessParcel/sheet/{sheet}/parcel/{parcel}/sbi/{sbi}/list"].get.parameters[1].schema.examples = [3756,8463,7211] |
 .paths["/SitiAgriApi/cv/landUseByBusinessParcel/sheet/{sheet}/parcel/{parcel}/sbi/{sbi}/list"].get.parameters[2].schema.examples = [107183280]'
-    kits=true
+    gateway="kits-internal"
+    ;;
+  # KITS APIs (EXTERNAL gateway)
+  perm | permissions )
+    schema="kits-v1/permissions"
+    resolve_defra_id_token
+    mutations='. |
+.paths["/SitiAgriApi/authorisation/organisation/{orgId}/byFunction"].get.parameters[0].schema.examples = ['"${ORG_ID:-5583781}"']'
+    gateway="kits-external"
     ;;
   # Hitachi API
   pd | payments )
     schema="hitachi/payments"
     mutations='. |
 .components.schemas.PaymentsRequest.properties.payment.properties.SupplierAccount.examples = ["5411707635","5305137528","4002722019"]'
+    gateway="hitachi"
     ;;
   *)
     echo "ERROR: Invalid argument: $1" 1>&2
@@ -136,7 +185,7 @@ yq eval -o=json -- "${mutations}" ${rootDir}/src/routes/${schema}-schema.oas.yml
   | tee ./tmp/schema.json > /dev/null
 
 # run schemathesis tests
-if ${kits} ; then # KITS gateway
+if [ "${gateway}" = "kits-internal" ]; then # KITS internal gateway
   if [ -z "${CDP_API_KEY}" ]; then
     echo "ERROR: CDP_API_KEY environment variable is not set" 1>&2
     usage
@@ -153,7 +202,34 @@ if ${kits} ; then # KITS gateway
         --header "x-api-key: ${CDP_API_KEY}" \
         --exclude-checks=unsupported_method,not_a_server_error \
         --report-vcr-path /tmp/vcr.yaml \
-        --url "${KITS_URL:-https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi}"
+        --url "${KITS_INTERNAL_URL:-https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi}"
+
+elif [ "${gateway}" = "kits-external" ]; then # KITS EXTERNAL gateway
+  if [ -z "${CDP_API_KEY}" ]; then
+    echo "ERROR: CDP_API_KEY environment variable is not set" 1>&2
+    usage
+    exit 1
+  fi
+  if [ -z "${CRN}" ]; then
+    echo "ERROR: CRN is not set and could not be derived from the Defra ID token" 1>&2
+    usage
+    exit 1
+  fi
+
+  # NOTE: endpoint-specific check exclusions are configured in schemathesis.toml
+  # NOTE: the KITS external gateway expects the RAW Defra ID JWT in Authorization without `Bearer` prefix
+  docker run --rm --network=host --pull always \
+    -v ${baseDir}/tmp:/tmp \
+    -v ${baseDir}/schemathesis.toml:/tmp/schemathesis.toml:ro \
+    schemathesis/schemathesis:stable \
+      --config-file /tmp/schemathesis.toml \
+      run /tmp/schema.json \
+        --header "x-api-key: ${CDP_API_KEY}" \
+        --header "Authorization: ${DEFRA_ID_TOKEN}" \
+        --header "crn: ${CRN}" \
+        --exclude-checks=unsupported_method,not_a_server_error \
+        --report-vcr-path /tmp/vcr.yaml \
+        --url "${KITS_EXTERNAL_URL:-https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/external/extapi}"
 
 else # hitachi
   if [ -z "${HITACHI_CLIENT_SECRET}" ]; then
@@ -187,6 +263,3 @@ else # hitachi
         --report-vcr-path /tmp/vcr.yaml \
         --url "${HITACHI_URL:-https://orgcf202fa2.operations.eu.dynamics.com/api}"
 fi
-
-# cleanup
-rm -rf ./tmp

--- a/test/contract/compose.yml
+++ b/test/contract/compose.yml
@@ -8,7 +8,7 @@ services:
       - -c
       - |
         result=0
-        for schema in person organisation authenticate siti-agri land bank reference-data payments ; do
+        for schema in person organisation authenticate siti-agri land bank reference-data permissions payments ; do
           echo "Running contract tests for schema: $${schema}"
           auth_header="email: $${TEST_USER_EMAIL:-testuser01@defra.gov.uk}"
           if [ "$${schema}" = "payments" ]; then auth_header='Authorization: bearer token'; fi

--- a/test/integration/routes/kits-v1/siti-agri/permissions.test.js
+++ b/test/integration/routes/kits-v1/siti-agri/permissions.test.js
@@ -52,15 +52,13 @@ describe('Permissions (authorisation byFunction) route', () => {
     )
   })
 
-  it('returns the WAF-style HTML 403 for a non-integer orgId, like the upstream', async () => {
+  it('returns 403 for a non-integer orgId, like the upstream', async () => {
     const response = await server.inject({
       method: 'GET',
       url: `/SitiAgriApi/authorisation/organisation/not-an-id/byFunction?${query}`
     })
 
     expect(response.statusCode).toBe(403)
-    expect(response.headers['content-type']).toContain('text/html')
-    expect(response.payload).toContain('403 Forbidden')
   })
 
   it('returns the error envelope as a 500 when functions is missing, like the upstream', async () => {

--- a/test/integration/routes/kits-v1/siti-agri/permissions.test.js
+++ b/test/integration/routes/kits-v1/siti-agri/permissions.test.js
@@ -1,0 +1,127 @@
+import Hapi from '@hapi/hapi'
+import { retrieveAuthorisationByFunction } from '../../../../../src/factories/siti-agri/permissions.factory.js'
+import { permissions } from '../../../../../src/routes/kits-v1/permissions.js'
+import { loadSchema } from '../../../../../src/utils/validatePayload.js'
+
+const schemaPath = '/SitiAgriApi/authorisation/organisation/{orgId}/byFunction'
+
+describe('Permissions (authorisation byFunction) route', () => {
+  let server, schema
+  beforeAll(async () => {
+    server = Hapi.server()
+    server.route(permissions)
+    await Promise.all([
+      server.initialize(),
+      loadSchema('routes/kits-v1/permissions-schema.oas.yml').then((s) => (schema = s))
+    ])
+  })
+
+  const orgId = 5583781
+  const query =
+    'functions=viewLand|amendBusinessDetails|viewEntitlements&module=CUST_SS_PORTAL&timestamp=1720000000000'
+
+  it('returns the requested functions mapped to booleans, wrapped in the standard envelope', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/SitiAgriApi/authorisation/organisation/${orgId}/byFunction?${query}`
+    })
+
+    expect(response.statusCode).toBe(200)
+    const json = JSON.parse(response.payload)
+
+    expect(json.success).toBe(true)
+    expect(json.errorString).toBeNull()
+    expect(json.data).toEqual(
+      retrieveAuthorisationByFunction(orgId, [
+        'viewLand',
+        'amendBusinessDetails',
+        'viewEntitlements'
+      ])
+    )
+  })
+
+  it('conforms to the response schema', async () => {
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url: `/SitiAgriApi/authorisation/organisation/${orgId}/byFunction?${query}`
+    })
+
+    expect(statusCode).toBe(200)
+    expect(result).toConformToSchema(
+      schema.paths[schemaPath].get.responses['200'].content['application/json'].schema
+    )
+  })
+
+  it('returns the WAF-style HTML 403 for a non-integer orgId, like the upstream', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/SitiAgriApi/authorisation/organisation/not-an-id/byFunction?${query}`
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect(response.headers['content-type']).toContain('text/html')
+    expect(response.payload).toContain('403 Forbidden')
+  })
+
+  it('returns the error envelope as a 500 when functions is missing, like the upstream', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/SitiAgriApi/authorisation/organisation/${orgId}/byFunction?module=CUST_SS_PORTAL&timestamp=1720000000000`
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(JSON.parse(response.payload)).toEqual({
+      data: null,
+      success: false,
+      errorString: 'An error has occurred.'
+    })
+  })
+
+  it('returns the error envelope as a 500 when module is missing, like the upstream', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/SitiAgriApi/authorisation/organisation/${orgId}/byFunction?functions=viewLand&timestamp=1720000000000`
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(JSON.parse(response.payload)).toEqual({
+      data: null,
+      success: false,
+      errorString: 'An error has occurred.'
+    })
+  })
+
+  it('returns false for every function when the module is unrecognised, like the upstream', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/SitiAgriApi/authorisation/organisation/${orgId}/byFunction?functions=viewLand|viewCPH&module=NOPE&timestamp=1720000000000`
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.payload).data).toEqual({ viewLand: false, viewCPH: false })
+  })
+
+  it('matches the module case-insensitively, like the upstream', async () => {
+    const [upper, lower] = await Promise.all(
+      ['CUST_SS_PORTAL', 'cust_ss_portal'].map((module) =>
+        server.inject({
+          method: 'GET',
+          url: `/SitiAgriApi/authorisation/organisation/${orgId}/byFunction?functions=viewLand&module=${module}`
+        })
+      )
+    )
+
+    expect(lower.statusCode).toBe(200)
+    expect(JSON.parse(lower.payload)).toEqual(JSON.parse(upper.payload))
+  })
+
+  it('echoes an empty functions list back as a single empty-named flag, like the upstream', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: `/SitiAgriApi/authorisation/organisation/${orgId}/byFunction?functions=&module=CUST_SS_PORTAL&timestamp=1720000000000`
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.payload).data).toEqual({ '': false })
+  })
+})

--- a/test/unit/factories/permissions.factory.test.js
+++ b/test/unit/factories/permissions.factory.test.js
@@ -63,9 +63,11 @@ describe('permissions.factory', () => {
       expect(data).toEqual({ notARealFunction: false })
     })
 
-    it('recognises every function documented in the OAS AuthorisationData schema', async () => {
+    it('recognises every function documented in the OAS response schema', async () => {
       const schema = await loadSchema('routes/kits-v1/permissions-schema.oas.yml')
-      const documented = Object.keys(schema.components.schemas.AuthorisationData.properties)
+      const documented = Object.keys(
+        schema.components.schemas.AuthorisationByFunctionResponse.properties.data.properties
+      )
       expect([...KNOWN_FUNCTIONS].sort()).toEqual(documented.sort())
     })
   })

--- a/test/unit/factories/permissions.factory.test.js
+++ b/test/unit/factories/permissions.factory.test.js
@@ -1,0 +1,72 @@
+import {
+  KNOWN_FUNCTIONS,
+  retrieveAuthorisationByFunction
+} from '../../../src/factories/siti-agri/permissions.factory.js'
+import { loadSchema } from '../../../src/utils/validatePayload.js'
+
+describe('permissions.factory', () => {
+  describe('retrieveAuthorisationByFunction', () => {
+    it('returns a boolean for each requested function, keyed in request order', () => {
+      const functions = ['viewLand', 'amendBusinessDetails', 'viewEntitlements']
+      const data = retrieveAuthorisationByFunction(5583781, functions)
+
+      expect(Object.keys(data)).toEqual(functions)
+      for (const value of Object.values(data)) {
+        expect(typeof value).toBe('boolean')
+      }
+    })
+
+    it('is deterministic for the same orgId and functions', () => {
+      const functions = ['viewLand', 'amendEntitlements']
+      const first = retrieveAuthorisationByFunction(5849659, functions)
+      const second = retrieveAuthorisationByFunction(5849659, functions)
+
+      expect(second).toEqual(first)
+    })
+
+    it('gives each function a stable flag regardless of request order or accompanying functions', () => {
+      const alone = retrieveAuthorisationByFunction(5583781, ['viewLand'])
+      const reordered = retrieveAuthorisationByFunction(5583781, [
+        'amendEntitlements',
+        'viewLand',
+        'viewCPH'
+      ])
+
+      expect(reordered.viewLand).toBe(alone.viewLand)
+    })
+
+    it('produces a different spread of permissions for different organisations', () => {
+      const functions = [
+        'viewLand',
+        'amendBusinessDetails',
+        'viewEntitlements',
+        'viewCPH',
+        'amendEntitlements',
+        'viewApplication',
+        'submitApplication',
+        'closeBusiness',
+        'viewBusinessDetails',
+        'applyForBPS'
+      ]
+      const first = retrieveAuthorisationByFunction(5583781, functions)
+      const second = retrieveAuthorisationByFunction(5852711, functions)
+
+      expect(second).not.toEqual(first)
+    })
+
+    it('returns an empty object when no functions are requested', () => {
+      expect(retrieveAuthorisationByFunction(5583781, [])).toEqual({})
+    })
+
+    it('echoes back unrecognised function names as false, like the upstream', () => {
+      const data = retrieveAuthorisationByFunction(5583781, ['notARealFunction'])
+      expect(data).toEqual({ notARealFunction: false })
+    })
+
+    it('recognises every function documented in the OAS AuthorisationData schema', async () => {
+      const schema = await loadSchema('routes/kits-v1/permissions-schema.oas.yml')
+      const documented = Object.keys(schema.components.schemas.AuthorisationData.properties)
+      expect([...KNOWN_FUNCTIONS].sort()).toEqual(documented.sort())
+    })
+  })
+})

--- a/test/unit/routes/permissions.test.js
+++ b/test/unit/routes/permissions.test.js
@@ -1,0 +1,31 @@
+import { parseRequestedFunctions } from '../../../src/routes/kits-v1/permissions.js'
+
+describe('permissions route - parseRequestedFunctions', () => {
+  it('splits a pipe-separated function list', () => {
+    expect(parseRequestedFunctions('viewLand|amendBusinessDetails')).toEqual([
+      'viewLand',
+      'amendBusinessDetails'
+    ])
+  })
+
+  it('handles a single function', () => {
+    expect(parseRequestedFunctions('viewLand')).toEqual(['viewLand'])
+  })
+
+  it('drops empty tokens from trailing or doubled trailing pipes, like the upstream', () => {
+    expect(parseRequestedFunctions('viewLand||')).toEqual(['viewLand'])
+  })
+
+  it('keeps leading and middle empty tokens, like the upstream', () => {
+    expect(parseRequestedFunctions('|viewLand')).toEqual(['', 'viewLand'])
+    expect(parseRequestedFunctions('viewLand||viewCPH')).toEqual(['viewLand', '', 'viewCPH'])
+  })
+
+  it('returns a single empty token for an empty list, like the upstream', () => {
+    expect(parseRequestedFunctions('')).toEqual([''])
+  })
+
+  it('returns no tokens when the list is only pipes, like the upstream', () => {
+    expect(parseRequestedFunctions('||')).toEqual([])
+  })
+})

--- a/test/unit/routes/schemata.test.js
+++ b/test/unit/routes/schemata.test.js
@@ -9,7 +9,7 @@ describe('Fake Person', () => {
     await server.register([inert, schemata])
     await server.initialize()
   })
-  ;['authenticate', 'person', 'organisation', 'siti-agri'].forEach((schema) => {
+  ;['authenticate', 'person', 'organisation', 'siti-agri', 'permissions'].forEach((schema) => {
     it(`should fetch the ${schema} schema file`, async () => {
       const result = await server.inject({
         method: 'GET',


### PR DESCRIPTION
Add new mock endpoint `/SitiAgriApi/authorisation/organisation/{orgId}/{byFunction}`

 - Extended contract tests to cover external endpoints ( you will need a defra id token )
 - Added script to generate Defra ID token ( no creds to do this yet though )

I have renamed some env vars for contract tests, see the example.env