### PR TITLE
fix: date of birth validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1882,9 +1882,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2349,9 +2349,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -2998,9 +2998,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -4205,9 +4205,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -4804,9 +4804,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4945,9 +4945,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5536,9 +5536,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -5556,7 +5556,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/routes/kits-v1/person-schema.oas.yml
+++ b/src/routes/kits-v1/person-schema.oas.yml
@@ -388,9 +388,9 @@ components:
             - type: integer
               format: int64
               minimum: -999999999999999
-              maximum: 999999999999
+              maximum: 9999999999999
             - type: string
-              pattern: '^(-[0-9]{1,15}$|^[0-9]{1,12})?$'
+              pattern: '^(-[0-9]{1,15}$|^[0-9]{1,13})?$'
             - type: 'null'
         landline:
           oneOf:

--- a/src/routes/kits-v1/person-schema.oas.yml
+++ b/src/routes/kits-v1/person-schema.oas.yml
@@ -383,14 +383,12 @@ components:
             - type: boolean
           description: 'Last name of the person'
         dateOfBirth:
-          description: 'Date of birth as a Unix timestamp'
+          description: 'Date of birth as a Unix timestamp in milliseconds. Must be in the past (enforced at runtime)'
           oneOf:
             - type: integer
               format: int64
-              minimum: -999999999999999
-              maximum: 9999999999999
             - type: string
-              pattern: '^(-[0-9]{1,15}$|^[0-9]{1,13})?$'
+              pattern: '^-?[0-9]+$'
             - type: 'null'
         landline:
           oneOf:

--- a/src/routes/kits-v1/person.js
+++ b/src/routes/kits-v1/person.js
@@ -44,6 +44,21 @@ const mapPersonToSearchResult = ({
   deactivated
 })
 
+// Emulates Oracle's RR year windowing: years 0-49 become 2000-2049, years 50-99 become 1950-1999
+const applyOracleYearWindowing = (timestamp) => {
+  const date = new Date(timestamp)
+  const year = date.getUTCFullYear()
+  if (year >= 0 && year <= 49) {
+    date.setUTCFullYear(year + 2000)
+    return date.getTime()
+  }
+  if (year >= 50 && year <= 99) {
+    date.setUTCFullYear(year + 1900)
+    return date.getTime()
+  }
+  return timestamp
+}
+
 const validateUpdatePersonPayload = await createPayloadValidator(
   'routes/kits-v1/person-schema.oas.yml',
   (schema) => schema.paths['/person/{personId}'].put.requestBody.content['application/json'].schema
@@ -132,6 +147,14 @@ export const person = [
 
       if (!validateUpdatePersonPayload(request.payload)) {
         throw Boom.badData('validation error while processing input', request)
+      }
+
+      const dob = body.dateOfBirth != null ? Number(body.dateOfBirth) : null
+      if (dob != null) {
+        body.dateOfBirth = applyOracleYearWindowing(dob)
+        if (body.dateOfBirth >= Date.now()) {
+          throw Boom.badData('validation error while processing input', request)
+        }
       }
 
       updatePerson(personId, body)

--- a/test/integration/routes/kits-v1/person/person.test.js
+++ b/test/integration/routes/kits-v1/person/person.test.js
@@ -298,9 +298,7 @@ describe('Person routes', () => {
       })
     })
 
-    test('should accept a dateOfBirth returned by GET /person/{personId}/summary', async () => {
-      // Regression: the schema previously capped dateOfBirth at 999999999999 (2001-09-09),
-      // causing PUT to reject values the GET endpoint itself returned for post-2001 dates.
+    test('should accept a post-2001 dateOfBirth returned by GET', async () => {
       const { result: personFixture } = await server.inject({
         method: 'GET',
         url: '/person/11111119/summary'
@@ -308,6 +306,7 @@ describe('Person routes', () => {
 
       const { dateOfBirth } = personFixture._data
       expect(dateOfBirth).toBeGreaterThan(999999999999)
+      expect(dateOfBirth).toBeLessThan(Date.now())
 
       const { statusCode } = await server.inject({
         method: 'PUT',
@@ -321,6 +320,103 @@ describe('Person routes', () => {
       })
 
       expect(statusCode).toBe(204)
+    })
+
+    test('should reject a dateOfBirth that is tomorrow or later', async () => {
+      const tomorrow = Date.now() + 86400000
+
+      const { statusCode } = await server.inject({
+        method: 'PUT',
+        url: '/person/11111119',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: {
+          firstName: 'Test',
+          lastName: 'User',
+          dateOfBirth: tomorrow
+        }
+      })
+
+      expect(statusCode).toBe(422)
+    })
+
+    // Oracle RR year windowing: years 0-49 become 2000+year, years 50-99 become 1900+year.
+    // The "must be in the past" check runs AFTER windowing.
+
+    test('year 0001 is windowed to 2001 and accepted (in the past)', async () => {
+      const date = new Date('0001-04-05T00:00:00.000Z')
+      date.setUTCFullYear(1)
+
+      const { statusCode } = await server.inject({
+        method: 'PUT',
+        url: '/person/11111119',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: { firstName: 'Test', lastName: 'User', dateOfBirth: date.getTime() }
+      })
+      expect(statusCode).toBe(204)
+
+      const { result } = await server.inject({ method: 'GET', url: '/person/11111119/summary' })
+      expect(new Date(result._data.dateOfBirth).getUTCFullYear()).toBe(2001)
+    })
+
+    test('year 0026 is windowed to 2026 and accepted if before today', async () => {
+      const date = new Date('0026-01-01T00:00:00.000Z')
+      date.setUTCFullYear(26)
+
+      const { statusCode } = await server.inject({
+        method: 'PUT',
+        url: '/person/11111119',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: { firstName: 'Test', lastName: 'User', dateOfBirth: date.getTime() }
+      })
+      expect(statusCode).toBe(204)
+
+      const { result } = await server.inject({ method: 'GET', url: '/person/11111119/summary' })
+      expect(new Date(result._data.dateOfBirth).getUTCFullYear()).toBe(2026)
+    })
+
+    test('year 0049 is windowed to 2049 and rejected (in the future)', async () => {
+      const date = new Date('0049-04-05T00:00:00.000Z')
+      date.setUTCFullYear(49)
+
+      const { statusCode } = await server.inject({
+        method: 'PUT',
+        url: '/person/11111119',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: { firstName: 'Test', lastName: 'User', dateOfBirth: date.getTime() }
+      })
+      expect(statusCode).toBe(422)
+    })
+
+    test('year 0050 is windowed to 1950 and accepted (in the past)', async () => {
+      const date = new Date('0050-04-05T00:00:00.000Z')
+      date.setUTCFullYear(50)
+
+      const { statusCode } = await server.inject({
+        method: 'PUT',
+        url: '/person/11111119',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: { firstName: 'Test', lastName: 'User', dateOfBirth: date.getTime() }
+      })
+      expect(statusCode).toBe(204)
+
+      const { result } = await server.inject({ method: 'GET', url: '/person/11111119/summary' })
+      expect(new Date(result._data.dateOfBirth).getUTCFullYear()).toBe(1950)
+    })
+
+    test('year 0099 is windowed to 1999 and accepted (in the past)', async () => {
+      const date = new Date('0099-04-05T00:00:00.000Z')
+      date.setUTCFullYear(99)
+
+      const { statusCode } = await server.inject({
+        method: 'PUT',
+        url: '/person/11111119',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: { firstName: 'Test', lastName: 'User', dateOfBirth: date.getTime() }
+      })
+      expect(statusCode).toBe(204)
+
+      const { result } = await server.inject({ method: 'GET', url: '/person/11111119/summary' })
+      expect(new Date(result._data.dateOfBirth).getUTCFullYear()).toBe(1999)
     })
   })
 })

--- a/test/integration/routes/kits-v1/person/person.test.js
+++ b/test/integration/routes/kits-v1/person/person.test.js
@@ -297,5 +297,30 @@ describe('Person routes', () => {
         message: 'validation error while processing input'
       })
     })
+
+    test('should accept a dateOfBirth returned by GET /person/{personId}/summary', async () => {
+      // Regression: the schema previously capped dateOfBirth at 999999999999 (2001-09-09),
+      // causing PUT to reject values the GET endpoint itself returned for post-2001 dates.
+      const { result: personFixture } = await server.inject({
+        method: 'GET',
+        url: '/person/11111119/summary'
+      })
+
+      const { dateOfBirth } = personFixture._data
+      expect(dateOfBirth).toBeGreaterThan(999999999999)
+
+      const { statusCode } = await server.inject({
+        method: 'PUT',
+        url: '/person/11111119',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: {
+          firstName: personFixture._data.firstName,
+          lastName: personFixture._data.lastName,
+          dateOfBirth
+        }
+      })
+
+      expect(statusCode).toBe(204)
+    })
   })
 })


### PR DESCRIPTION
fix(no-jira): fix date of birth validation to match upstream behaviour

The PersonalUpdateRequest schema used an artificial maximum and regex digit-count cap that did not reflect real upstream (KITS) behaviour. This caused PUT to reject timestamps the GET endpoint itself returned.

Upstream behaviour (verified against capd-services and live testing):
- DateOfBirthValidator.java:11: sole constraint is value.before(new Date())
- Oracle RR year windowing applies before validation:
  - Years 0–49 become 2000+year (e.g. 0001→2001, 0026→2026)
  - Years 50–99 become 1900+year (e.g. 0050→1950, 0099→1999)
- Windowed result is then checked against "must be in the past"
  - 0049→2049 is rejected (future)
  - 0050→1950 is accepted (past)
