### PR TITLE
FCPDAL-468 - Defra ID generation for contract tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,13 +29,17 @@
       "devDependencies": {
         "@redocly/cli": "1.29.0",
         "@vitest/coverage-v8": "4.1.9",
+        "acorn": "8.16.0",
         "dotenv-cli": "^10.0.0",
         "eslint": "^9.32.0",
         "eslint-plugin-import": "^2.31.0",
         "globals": "^17.7.0",
+        "got": "15.1.0",
         "husky": "^9.1.6",
+        "node-html-parser": "9.0.0",
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3",
+        "tough-cookie": "6.0.2",
         "vitest": "^4.1.9"
       },
       "engines": {
@@ -889,6 +893,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1330,6 +1341,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1369,6 +1400,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1881,6 +1919,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -1903,6 +1948,58 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/byte-counter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+      "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "13.0.19",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
+      "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.2.0",
+        "get-stream": "^9.0.1",
+        "http-cache-semantics": "^4.2.0",
+        "keyv": "^5.6.0",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.1.1",
+        "responselike": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/call-bind": {
@@ -2031,6 +2128,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chunk-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/classnames": {
@@ -2166,6 +2276,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -2176,6 +2303,19 @@
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -2272,6 +2412,22 @@
       "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
       "dev": true
     },
+    "node_modules/decompress-response": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+      "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2348,6 +2504,63 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.4.11",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
@@ -2356,6 +2569,21 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -2445,6 +2673,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -3303,6 +3544,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3397,6 +3655,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^8.0.0",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.18",
+        "chunk-data": "^0.1.0",
+        "decompress-response": "^10.0.0",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.6.0",
+        "lowercase-keys": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^5.6.0",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/handlebars": {
@@ -3577,12 +3872,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http2-client": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
       "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -4008,6 +4324,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -4595,6 +4924,19 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -4709,6 +5051,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -4895,6 +5250,17 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-9.0.0.tgz",
+      "integrity": "sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "entities": "^8.0.0"
+      }
+    },
     "node_modules/node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
@@ -5004,6 +5370,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oas-kit-common": {
@@ -5689,6 +6081,19 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5928,6 +6333,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5936,6 +6348,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+      "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rolldown": {
@@ -6652,6 +7093,19 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -6705,6 +7159,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6726,6 +7200,19 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -6783,6 +7270,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6875,6 +7378,19 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,9 +1030,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1927,9 +1927,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2562,9 +2562,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -3239,9 +3239,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -4534,9 +4534,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -5159,9 +5159,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5311,9 +5311,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5928,9 +5928,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -5948,7 +5948,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
     "test:contract": "docker compose -f compose.yml -f test/contract/compose.yml run --quiet-pull --pull always --build --rm contract-tests",
     "verify:schemata": "redocly lint src/routes/**/*-schema*.yml",
-    "test:contract:local": "dotenv -- ./test/contract/check-schema.sh"
+    "test:contract:local": "dotenv -- ./test/contract/check-schema.sh",
+    "test:contract:local:external": "dotenv -e .env.defraid -e .env -- ./test/contract/check-external-schema.sh"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",
@@ -45,13 +46,17 @@
   "devDependencies": {
     "@redocly/cli": "1.29.0",
     "@vitest/coverage-v8": "4.1.9",
+    "acorn": "8.16.0",
     "dotenv-cli": "^10.0.0",
     "eslint": "^9.32.0",
     "eslint-plugin-import": "^2.31.0",
     "globals": "^17.7.0",
+    "got": "15.1.0",
     "husky": "^9.1.6",
+    "node-html-parser": "9.0.0",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3",
+    "tough-cookie": "6.0.2",
     "vitest": "^4.1.9"
   },
   "overrides": {

--- a/scripts/get-defra-id-token.js
+++ b/scripts/get-defra-id-token.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+import * as acorn from 'acorn'
+import got from 'got'
+import { parse as parseHtml } from 'node-html-parser'
+import crypto from 'node:crypto'
+import { CookieJar } from 'tough-cookie'
+
+const UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
+const MAX_ROUNDS = 8
+
+const REQUIRED_CONFIG = {
+  crn: 'CRN',
+  password: 'PASSWORD',
+  wellKnownUrl: 'DEFRA_ID_WELL_KNOWN_URL',
+  clientId: 'DEFRA_ID_CLIENT_ID',
+  clientSecret: 'DEFRA_ID_CLIENT_SECRET',
+  serviceId: 'DEFRA_ID_SERVICE_ID',
+  policy: 'DEFRA_ID_POLICY',
+  redirectUrl: 'DEFRA_ID_REDIRECT_URL'
+}
+const OPTIONAL_CONFIG = { relationshipId: 'DEFRA_ID_RELATIONSHIP_ID' }
+
+const readConfig = () => {
+  const config = Object.fromEntries(
+    Object.entries({ ...REQUIRED_CONFIG, ...OPTIONAL_CONFIG }).map(([key, envVar]) => [
+      key,
+      process.env[envVar]
+    ])
+  )
+  const missing = Object.entries(REQUIRED_CONFIG)
+    .filter(([key]) => !config[key])
+    .map(([, envVar]) => envVar)
+  if (missing.length) {
+    throw new Error(
+      `Missing required config: ${missing.join(', ')} (read from the environment; ` +
+        'run via `npm run test:contract:local:external` to load .env.defraid).' +
+        (missing.includes('DEFRA_ID_CLIENT_SECRET')
+          ? '\nDEFRA_ID_CLIENT_SECRET is not in the local .env (local stack uses the Defra ID stub). Add the real CDP secret.'
+          : '')
+    )
+  }
+  return { ...config, scope: `openid offline_access ${config.clientId}` }
+}
+
+const cookieJar = new CookieJar()
+const http = got.extend({
+  cookieJar,
+  methodRewriting: true,
+  throwHttpErrors: false,
+  maxRedirects: 20,
+  retry: { limit: 0 },
+  headers: {
+    'user-agent': UA,
+    accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+  }
+})
+
+const tryJson = (body) => {
+  try {
+    return JSON.parse(body)
+  } catch {
+    return {}
+  }
+}
+
+const parseSettings = (html) => {
+  const script = parseHtml(html)
+    .querySelectorAll('script')
+    .find((el) => el.rawText.includes('var SETTINGS = {'))
+  if (!script) return null
+  let settings
+  try {
+    const declaration = acorn
+      .parse(script.rawText, { ecmaVersion: 'latest' })
+      .body.filter((node) => node.type === 'VariableDeclaration')
+      .flatMap((node) => node.declarations)
+      .find((node) => node.id.name === 'SETTINGS')
+    settings = JSON.parse(script.rawText.slice(declaration.init.start, declaration.init.end))
+  } catch {
+    return null
+  }
+  return {
+    csrf: settings.csrf ?? null,
+    transId: settings.transId ?? null,
+    api: settings.api ?? null,
+    tenant: settings.hosts?.tenant ?? null,
+    policy: settings.hosts?.policy ?? null
+  }
+}
+
+const parseFieldIds = (html) =>
+  [...html.matchAll(/"ID"\s*:\s*"([^"]*)"/g)].map((m) => m[1]).filter(Boolean)
+
+const discoverEndpoints = async (wellKnownUrl) => {
+  const oidc = await http(wellKnownUrl, { headers: { accept: 'application/json' } }).json()
+  return {
+    authorizeEndpoint: oidc.authorization_endpoint,
+    tokenEndpoint: oidc.token_endpoint,
+    b2cBase: new URL(oidc.authorization_endpoint).origin
+  }
+}
+
+const passFrontDoor = async (authorizeEndpoint, b2cBase, config) => {
+  const state = crypto.randomUUID()
+  const authorizeUrl =
+    authorizeEndpoint +
+    '?' +
+    new URLSearchParams({
+      client_id: config.clientId,
+      response_type: 'code',
+      redirect_uri: config.redirectUrl,
+      scope: config.scope,
+      response_mode: 'query',
+      state,
+      nonce: crypto.randomUUID(),
+      serviceId: config.serviceId,
+      p: config.policy
+    })
+  const gatePage = await http.get(authorizeUrl)
+  const crumb = parseHtml(gatePage.body).querySelector('input[name="crumb"]')?.getAttribute('value')
+  if (!crumb) throw new Error('Did not reach the idphub check-js page (unexpected journey).')
+
+  const checkJsUrl = new URL('/registration/journey/check-js/check-js-enabled', gatePage.url).href
+  const resumePage = await http.post(checkJsUrl, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Referer: checkJsUrl },
+    body: new URLSearchParams({ crumb, checkJs: '' }).toString()
+  })
+  const callbackForm = parseHtml(resumePage.body).querySelector('form[action*="authresp"]')
+  const callbackAction = callbackForm?.getAttribute('action')
+  const cbCode = callbackForm?.querySelector('input[name="code"]')?.getAttribute('value')
+  const cbState = callbackForm?.querySelector('input[name="state"]')?.getAttribute('value')
+  if (!callbackAction || !cbCode)
+    throw new Error('idphub did not return a callback code (check-js gate failed).')
+
+  const page = await http.post(callbackAction, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Referer: `${b2cBase}/` },
+    body: new URLSearchParams({ code: cbCode, state: cbState }).toString()
+  })
+  return { page, state }
+}
+
+const completeSelfAssertedRounds = async (startPage, b2cBase, config) => {
+  let page = startPage
+  const redirectOrigin = new URL(config.redirectUrl).origin
+  const appRedirect = (response) => {
+    const location = response.headers.location
+    if (!location) return null
+    const next = new URL(location, response.url)
+    return next.href.startsWith(redirectOrigin) ? next : null
+  }
+
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    const settings = parseSettings(page.body)
+    if (!settings || !settings.csrf || !settings.transId) {
+      throw new Error(
+        `Expected a B2C SelfAsserted page but found none (round ${round}). ` +
+          (/error/i.test(page.body)
+            ? 'The page mentions an error — check credentials.'
+            : 'Journey may have changed.')
+      )
+    }
+    const fields = parseFieldIds(page.body)
+    const body = new URLSearchParams({ request_type: 'RESPONSE' })
+    if (fields.includes('crn')) {
+      body.set('crn', config.crn)
+      body.set('password', config.password)
+    } else if (fields.includes('currentRelationshipId')) {
+      if (!config.relationshipId) {
+        throw new Error(
+          'This account has multiple businesses and pure-HTTP cannot list them\n' +
+            '(they are rendered client-side from a "picker" resource).\n' +
+            'Re-run with DEFRA_ID_RELATIONSHIP_ID set.'
+        )
+      }
+      body.set('currentRelationshipId', config.relationshipId)
+    } else {
+      for (const field of fields) body.set(field, '')
+    }
+
+    const saUrl = `${b2cBase}${settings.tenant}/SelfAsserted?tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`
+    const saRes = await http.post(saUrl, {
+      followRedirect: false,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        'X-CSRF-TOKEN': settings.csrf,
+        'X-Requested-With': 'XMLHttpRequest',
+        Referer: `${b2cBase}${settings.tenant}/`
+      },
+      body: body.toString()
+    })
+    const saJson = tryJson(saRes.body)
+    if (!saRes.ok || (saJson.status && String(saJson.status) !== '200')) {
+      throw new Error(
+        `B2C rejected the step (HTTP ${saRes.statusCode}, status ${saJson.status ?? 'none'}): ` +
+          (saJson.message || saRes.body.slice(0, 200))
+      )
+    }
+
+    const confirmedUrl = `${b2cBase}${settings.tenant}/api/${settings.api}/confirmed?rememberMe=false&csrf_token=${settings.csrf}&tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`
+    const confirmed = await http.get(confirmedUrl, {
+      followRedirect: (response) => !appRedirect(response)
+    })
+    const redirectToApp = appRedirect(confirmed)
+    if (!redirectToApp) {
+      page = confirmed
+      continue
+    }
+
+    const err = redirectToApp.searchParams.get('error')
+    if (err) {
+      throw new Error(
+        `Defra Identity returned error: ${err} - ${redirectToApp.searchParams.get('error_description') || ''}`
+      )
+    }
+    const code = redirectToApp.searchParams.get('code')
+    if (!code) {
+      throw new Error(
+        `Redirected to ${config.redirectUrl} with neither a code nor an error (unexpected journey).`
+      )
+    }
+    return { code, state: redirectToApp.searchParams.get('state') }
+  }
+
+  throw new Error(`Completed ${MAX_ROUNDS} journey rounds without a redirect back to the app.`)
+}
+
+const redeemCode = async (tokenEndpoint, code, config) => {
+  const tokenRes = await http.post(tokenEndpoint, {
+    followRedirect: false,
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: config.redirectUrl,
+      scope: config.scope
+    }).toString()
+  })
+  const token = tryJson(tokenRes.body)
+  if (!tokenRes.ok || token.error) {
+    throw new Error(
+      `Token endpoint failed: HTTP ${tokenRes.statusCode}\n${token.error || ''}: ${(token.error_description || '').split(/\r?\n/)[0]}`
+    )
+  }
+
+  return token.access_token || token.id_token
+}
+
+const main = async () => {
+  const config = readConfig()
+  const { authorizeEndpoint, tokenEndpoint, b2cBase } = await discoverEndpoints(config.wellKnownUrl)
+  const { page, state } = await passFrontDoor(authorizeEndpoint, b2cBase, config)
+  const captured = await completeSelfAssertedRounds(page, b2cBase, config)
+  if (captured.state && captured.state !== state)
+    throw new Error('State mismatch on redirect (possible CSRF).')
+
+  console.log(await redeemCode(tokenEndpoint, captured.code, config))
+}
+
+main().catch((err) => {
+  console.error(process.env.DEFRA_ID_DEBUG ? err : err.message)
+  process.exitCode = 1
+})

--- a/test/contract/check-external-schema.sh
+++ b/test/contract/check-external-schema.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# setup
+baseDir=`cd $(dirname $0) ; pwd`
+cd "${baseDir}"
+rootDir=`cd ../.. ; pwd`
+
+usage() {
+  set +x
+  echo
+  echo "Run schemathesis contract tests against the upstream KITS EXTERNAL gateway."
+  echo "All tests are run against the 'upgrade' API env."
+  echo
+  echo "Usage: $0 {perm|permissions|help}"
+  echo
+  echo "Where the argument specifies which schema to test:"
+  echo "  perm | permissions       - test the Authorisation (Permissions) schema"
+  echo "  h    | help              - show this help message"
+  echo
+  echo "NOTE: additionally the following environment variables must be set:"
+  echo "  CDP_API_KEY - CDP Platform developer API key"
+  echo "  CRN         - customer reference number for the external user under test,"
+  echo "                sent as the 'crn' header and used to sign in to Defra Identity"
+  echo "  KITS_EXTERNAL_URL - the URL of the KITS EXTERNAL proxy endpoint (defaults to"
+  echo "                      the deployed mock's /proxy/external/extapi ephemeral route)"
+  echo
+  echo "The Defra Identity token is taken from DEFRA_ID_TOKEN if set; otherwise it is"
+  echo "generated with scripts/get-defra-id-token.js, which needs CRN plus:"
+  echo "  PASSWORD                - password for the CRN under test"
+  echo "  DEFRA_ID_WELL_KNOWN_URL - OIDC discovery document for the Defra ID tenant"
+  echo "  DEFRA_ID_CLIENT_ID      - Defra ID client id"
+  echo "  DEFRA_ID_CLIENT_SECRET  - Defra ID client secret (the real CDP one; the local"
+  echo "                            .env has no secret as the local stack uses the stub)"
+  echo "  DEFRA_ID_SERVICE_ID     - Defra ID service id"
+  echo "  DEFRA_ID_POLICY         - B2C policy name to run the journey against"
+  echo "  DEFRA_ID_REDIRECT_URL   - registered redirect URL the journey ends on"
+  echo "  DEFRA_ID_RELATIONSHIP_ID - optional; required only when the CRN is linked to"
+  echo "                            more than one business"
+  echo "  DEFRA_ID_DEBUG          - optional; set to print token generation stack traces"
+  echo
+  echo "These are normally supplied from .env.defraid via 'npm run test:contract:local:external'."
+}
+
+cleanup() {
+  local status=$?
+  if [ ${status} -ne 0 ] && [ -f "${baseDir}/tmp/vcr.yaml" ]; then
+    echo "NOTE: report from the failed run left at ${baseDir}/tmp/vcr.yaml" 1>&2
+    return
+  fi
+  rm -rf "${baseDir}/tmp"
+}
+
+# check OPTION argument
+case "${1:-}" in
+  h | help | --help | -h )
+    usage
+    exit 0
+    ;;
+  perm | permissions )
+    schema="kits-v1/permissions"
+    mutations='. |
+.paths["/SitiAgriApi/authorisation/organisation/{orgId}/byFunction"].get.parameters[0].schema.examples = [5583781]'
+    ;;
+  *)
+    echo "ERROR: Invalid argument: ${1:-<none>}" 1>&2
+    usage
+    exit 1
+esac
+
+# check required config
+if [ -z "${CDP_API_KEY}" ]; then
+  echo "ERROR: CDP_API_KEY environment variable is not set" 1>&2
+  usage
+  exit 1
+fi
+if [ -z "${CRN}" ]; then
+  echo "ERROR: CRN environment variable is not set (needed for the 'crn' header)" 1>&2
+  usage
+  exit 1
+fi
+
+# from here on ./tmp exists, so it is worth arranging for it to be tidied up again
+mkdir -p ./tmp
+trap cleanup EXIT
+
+yq eval -o=json -- "${mutations}" "${rootDir}/src/routes/${schema}-schema.oas.yml" \
+  | tee ./tmp/schema.json > /dev/null
+
+if [ -z "${DEFRA_ID_TOKEN}" ]; then
+  echo "Generating a Defra Identity token for the external gateway..."
+  DEFRA_ID_TOKEN=$( node "${rootDir}/scripts/get-defra-id-token.js" )
+fi
+if [ -z "${DEFRA_ID_TOKEN}" ]; then
+  echo "ERROR: DEFRA_ID_TOKEN was not generated correctly" 1>&2
+  usage
+  exit 1
+fi
+
+# run schemathesis tests against the EXTERNAL gateway
+# NOTE: endpoint-specific check exclusions are configured in schemathesis.toml
+docker run --rm --network=host --pull always \
+  -v "${baseDir}/tmp:/tmp" \
+  -v "${baseDir}/schemathesis.toml:/tmp/schemathesis.toml:ro" \
+  schemathesis/schemathesis:stable \
+    --config-file /tmp/schemathesis.toml \
+    run /tmp/schema.json \
+      --header "x-api-key: ${CDP_API_KEY}" \
+      --header "Authorization: Bearer ${DEFRA_ID_TOKEN}" \
+      --header "crn: ${CRN}" \
+      --exclude-checks=unsupported_method,not_a_server_error \
+      --report-vcr-path /tmp/vcr.yaml \
+      --url "${KITS_EXTERNAL_URL:-https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/external/extapi}"
+
+# NOTE: cleanup of ./tmp is handled by the `cleanup` EXIT trap set above


### PR DESCRIPTION
This change adds a script to automatically generate a Defra ID token when running contract tests against the external endpoint.