### PR TITLE
fix: convert dateOfBirth seconds to milliseconds on PUT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-upstream-mock",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-upstream-mock",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2998,9 +2998,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4205,9 +4205,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -6904,9 +6904,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-upstream-mock",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "fcp-dal-upstream-mock",
   "main": "src/index.js",
   "type": "module",

--- a/src/routes/kits-v1/person.js
+++ b/src/routes/kits-v1/person.js
@@ -138,7 +138,7 @@ export const person = [
       // The schema allows integer, string, or null; integers/strings may be negative (pre-1970).
       const rawDob = body.dateOfBirth
       if (rawDob != null) {
-        const secs = typeof rawDob === 'string' ? Number(rawDob) : rawDob
+        const secs = Number(rawDob)
         if (Number.isFinite(secs)) {
           body.dateOfBirth = secs * 1000
         }

--- a/src/routes/kits-v1/person.js
+++ b/src/routes/kits-v1/person.js
@@ -134,7 +134,13 @@ export const person = [
         throw Boom.badData('validation error while processing input', request)
       }
 
-      updatePerson(personId, body)
+      // Convert dateOfBirth from seconds (DAL) to milliseconds (stored format)
+      const updates =
+        typeof body.dateOfBirth === 'number' && body.dateOfBirth > 0
+          ? { ...body, dateOfBirth: body.dateOfBirth * 1000 }
+          : body
+
+      updatePerson(personId, updates)
       return h.response().code(204)
     }
   }

--- a/src/routes/kits-v1/person.js
+++ b/src/routes/kits-v1/person.js
@@ -134,13 +134,17 @@ export const person = [
         throw Boom.badData('validation error while processing input', request)
       }
 
-      // Convert dateOfBirth from seconds (DAL) to milliseconds (stored format)
-      const updates =
-        typeof body.dateOfBirth === 'number' && body.dateOfBirth > 0
-          ? { ...body, dateOfBirth: body.dateOfBirth * 1000 }
-          : body
+      // Convert dateOfBirth from seconds (DAL) to milliseconds (stored format).
+      // The schema allows integer, string, or null; integers/strings may be negative (pre-1970).
+      const rawDob = body.dateOfBirth
+      if (rawDob != null) {
+        const secs = typeof rawDob === 'string' ? Number(rawDob) : rawDob
+        if (Number.isFinite(secs)) {
+          body.dateOfBirth = secs * 1000
+        }
+      }
 
-      updatePerson(personId, updates)
+      updatePerson(personId, body)
       return h.response().code(204)
     }
   }

--- a/test/integration/routes/kits-v1/person/person.test.js
+++ b/test/integration/routes/kits-v1/person/person.test.js
@@ -297,5 +297,31 @@ describe('Person routes', () => {
         message: 'validation error while processing input'
       })
     })
+
+    test('should convert dateOfBirth from seconds to milliseconds on PUT', async () => {
+      const secondsSinceEpoch = 1735689600 // 2025-01-01
+      const expectedMilliseconds = 1735689600000
+
+      // fetch current state so we send a complete valid payload
+      const { result: current } = await server.inject({
+        method: 'GET',
+        url: '/person/11111111/summary'
+      })
+
+      const putResponse = await server.inject({
+        method: 'PUT',
+        url: '/person/11111111',
+        headers: { email: 'test@defra.gov.uk' },
+        payload: { ...current._data, dateOfBirth: secondsSinceEpoch }
+      })
+      expect(putResponse.statusCode).toBe(204)
+
+      const getResponse = await server.inject({
+        method: 'GET',
+        url: '/person/11111111/summary'
+      })
+      expect(getResponse.statusCode).toBe(200)
+      expect(getResponse.result._data.dateOfBirth).toBe(expectedMilliseconds)
+    })
   })
 })

--- a/test/integration/routes/kits-v1/person/person.test.js
+++ b/test/integration/routes/kits-v1/person/person.test.js
@@ -218,6 +218,7 @@ describe('Person routes', () => {
         firstName: 'test-first-name',
         middleName: 'test-middle-name',
         lastName: 'test-last-name',
+        // Input as seconds
         dateOfBirth: -2,
         landline: '01234 567890',
         mobile: '07111 222333',
@@ -257,7 +258,11 @@ describe('Person routes', () => {
         headers: {
           email: 'test@defra.gov.uk'
         },
-        payload: { ...payload, address: { ...payload.address, extra: 'chuff' }, more: 'jazz' }
+        payload: {
+          ...payload,
+          address: { ...payload.address, extra: 'chuff' },
+          more: 'jazz'
+        }
       })
       expect(response.statusCode).toBe(204)
       expect(response.payload).toBe('')
@@ -270,6 +275,8 @@ describe('Person routes', () => {
       expect(updated.statusCode).toBe(200)
       expect(updated.result._data).toEqual({
         ...payload,
+        // Output as milliseconds
+        dateOfBirth: -2000,
         // data which should not be updated remains the same
         customerReferenceNumber: personFixture._data.customerReferenceNumber,
         emailValidated: personFixture._data.emailValidated,
@@ -298,30 +305,35 @@ describe('Person routes', () => {
       })
     })
 
-    test('should convert dateOfBirth from seconds to milliseconds on PUT', async () => {
-      const secondsSinceEpoch = 1735689600 // 2025-01-01
-      const expectedMilliseconds = 1735689600000
+    test.each([
+      [1735689600, 1735689600000, 'positive number'],
+      [-1735689600, -1735689600000, 'negative number'],
+      ['1735689600', 1735689600000, 'positive string'],
+      ['-1735689600', -1735689600000, 'negative string']
+    ])(
+      'should convert dateOfBirth from seconds to milliseconds on PUT (%s)',
+      async (input, expected, description) => {
+        // fetch current state so we send a complete valid payload
+        const { result: current } = await server.inject({
+          method: 'GET',
+          url: '/person/11111111/summary'
+        })
 
-      // fetch current state so we send a complete valid payload
-      const { result: current } = await server.inject({
-        method: 'GET',
-        url: '/person/11111111/summary'
-      })
+        const putResponse = await server.inject({
+          method: 'PUT',
+          url: '/person/11111111',
+          headers: { email: 'test@defra.gov.uk' },
+          payload: { ...current._data, dateOfBirth: input }
+        })
+        expect(putResponse.statusCode).toBe(204)
 
-      const putResponse = await server.inject({
-        method: 'PUT',
-        url: '/person/11111111',
-        headers: { email: 'test@defra.gov.uk' },
-        payload: { ...current._data, dateOfBirth: secondsSinceEpoch }
-      })
-      expect(putResponse.statusCode).toBe(204)
-
-      const getResponse = await server.inject({
-        method: 'GET',
-        url: '/person/11111111/summary'
-      })
-      expect(getResponse.statusCode).toBe(200)
-      expect(getResponse.result._data.dateOfBirth).toBe(expectedMilliseconds)
-    })
+        const getResponse = await server.inject({
+          method: 'GET',
+          url: '/person/11111111/summary'
+        })
+        expect(getResponse.statusCode).toBe(200)
+        expect(getResponse.result._data.dateOfBirth).toBe(expected)
+      }
+    )
   })
 })


### PR DESCRIPTION
Ticket: [FCPDAL-482]

The DAL now sends dateOfBirth as seconds since epoch (e.g. 1735689600) to PUT /person/{personId}. The mock previously stored the value as-is, causing a mismatch with GET /person/{personId}/summary which returns milliseconds.

- Multiply incoming numeric dateOfBirth by 1000 before storing.
- Add regression test verifying seconds → milliseconds round-trip.
- Refactor to avoid mutating the request payload object.

[FCPDAL-482]: https://eaflood.atlassian.net/browse/FCPDAL-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ