### PR TITLE
Refactor DefraId token generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,41 +4,40 @@ PORT=3100
 # Pino log level (default 'info').
 #LOG_LEVEL=debug
 
-# --- Contract tests, KITS internal gateway (npm run test:contract:local) ---
+# --- Contract tests, KITS internal/external gateway ---
 # CDP Platform developer API key.
 CDP_API_KEY=
+
+# --- Contract tests, KITS internal gateway (npm run test:contract:local) ---
 # URL of the KITS API to test
 KITS_INTERNAL_URL=https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi
+
 # Email sent as the auth header (defaults to testuser01@defra.gov.uk).
-#TEST_USER_EMAIL=
+# TEST_USER_EMAIL=
 
 # --- Contract tests, KITS EXTERNAL gateway (npm run test:contract:local -- perm) ---
-# Pre-issued Defra Identity token; if unset one is generated with
-# scripts/get-defra-id-token.js, which needs CRN, DEFRA_ID_PASSWORD and the DEFRA_ID_* config.
-DEFRA_ID_TOKEN=
+
 # URL of the KITS EXTERNAL proxy endpoint.
 KITS_EXTERNAL_URL=https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/external/extapi
-# Customer reference number of the external user under test, sent as the `crn` header;
-# derived from the token's contactId claim when unset (required to generate a token).
-#CRN=
-# An organisation the CRN has a relationship with, used as the example orgId; derived
-# from the token's currentRelationshipId claim when unset.
-#ORG_ID=
 
-# --- Defra Identity OIDC client config (from CDP), for scripts/get-defra-id-token.js ---
-# Only needed when DEFRA_ID_TOKEN is not set; quote any value containing spaces.
-DEFRA_ID_WELL_KNOWN_URL=
-DEFRA_ID_CLIENT_ID=
-DEFRA_ID_CLIENT_SECRET=
-DEFRA_ID_SERVICE_ID=
-DEFRA_ID_POLICY=
-DEFRA_ID_REDIRECT_URL=
-# Password for the CRN under test (the token's user).
-DEFRA_ID_PASSWORD=
-# Required only when the CRN is linked to more than one business.
-#DEFRA_ID_RELATIONSHIP_ID=
-# Set to print token generation stack traces.
-#DEFRA_ID_DEBUG=1
+# There are two ways to run tests against the EXTERNAL gateway:
+# 1. with an already defined DEFRA ID Token:
+  # DEFRA_ID_TOKEN=           #Pre-issued Defra Identity token
+  # DEFRA_ID_CRN=             #Optional - Customer reference number of the external user under test, sent as the `crn` header; derived from the token's contactId claim when unset
+  # DEFRA_ID_RELATIONSHIP_ID= #Optional - The business (relationship) of the CRN under test, used as the example orgId; derived from the token's currentRelationshipId claim when unset
+
+# 2. generate a DEFRA ID token (for scripts/get-defra-id-token.js):
+  # DEFRA_ID_WELL_KNOWN_URL=https://your-account.cpdev.cui.defra.gov.uk/idphub/b2c/b2c_1a_cui_cpdev_signupsigninsfi/.well-known/openid-configuration
+  # DEFRA_ID_CLIENT_ID=
+  # DEFRA_ID_CLIENT_SECRET=
+  # DEFRA_ID_SERVICE_ID=
+  # DEFRA_ID_POLICY=b2c_1a_cui_cpdev_signupsigninsfi
+  # DEFRA_ID_REDIRECT_URL=https://fcp-dal-upstream-mock.dev.cdp-int.defra.cloud/auth/sign-in-oidc
+
+  # DEFRA_ID_CRN=             #Customer reference number of the external user under test, used to login to DEFRA ID
+  # DEFRA_ID_PASSWORD=        #Customer password used to login to DEFRA ID
+  # DEFRA_ID_RELATIONSHIP_ID= #Optional - If the customer is linked to multiple businesses this is used to select a specific business. If unset the first business is selected.
+  # DEFRA_ID_DEBUG=1          #Optional - Set to print token generation stack traces.
 
 # --- Contract tests, Hitachi payments (test/contract/check-schema.sh pd) ---
 # Client secret for AAD token generation.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Core delivery platform Node.js Backend Template.
   - [Formatting](#formatting)
     - [Windows prettier issue](#windows-prettier-issue)
 - [API endpoints](#api-endpoints)
+- [Schema testing against the KITS upgrade service](#schema-testing-against-the-kits-upgrade-service)
+  - [Testing against the external (Defra Identity) upstream](#testing-against-the-external-defra-identity-upstream)
 - [Docker](#docker)
   - [Development image](#development-image)
   - [Production image](#production-image)
@@ -162,6 +164,33 @@ to the KITS service, allowing schema verification. Access to this API is via the
 You can then access the proxy as shown in the following example
 
 > curl --header 'x-api-key: {API-KEY}' --header 'email: {EMAIL-ADDRESS}' https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/internal/extapi/person/3010037/summary
+
+### Testing against the external (Defra Identity) upstream
+
+The KITS **external** gateway (used by e.g. the permissions endpoints) authenticates with a Defra Identity token
+rather than an email header. A token can be generated without a browser using:
+
+```bash
+npm run generate:defraid-token
+```
+
+The script reads its configuration from `.env` (see [.env.example](./.env.example) for the full list). At a minimum
+you need the credentials of the user under test (`DEFRA_ID_CRN` and `DEFRA_ID_PASSWORD`) and the Defra Identity OIDC client
+config (`DEFRA_ID_WELL_KNOWN_URL`, `DEFRA_ID_CLIENT_ID`, `DEFRA_ID_CLIENT_SECRET`, `DEFRA_ID_SERVICE_ID`,
+`DEFRA_ID_POLICY` and `DEFRA_ID_REDIRECT_URL`). If the CRN is linked to more than one business, the first one is
+used; set `DEFRA_ID_RELATIONSHIP_ID` to pick a specific one.
+
+The token is printed to stdout; save it as `DEFRA_ID_TOKEN` in `.env` to reuse it.
+
+To run the contract tests against the external upstream, set `CDP_API_KEY` and `KITS_EXTERNAL_URL` in `.env`
+(again, see [.env.example](./.env.example)) and run:
+
+```bash
+npm run test:contract:local -- perm
+```
+
+If `DEFRA_ID_TOKEN` is not set, the test script generates one automatically using the same Defra Identity config.
+See the [contract testing README](./test/contract/README.md) for more detail.
 
 ## Docker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,14 +29,12 @@
       "devDependencies": {
         "@redocly/cli": "1.29.0",
         "@vitest/coverage-v8": "4.1.9",
-        "acorn": "^8.16.0",
         "dotenv-cli": "^10.0.0",
         "eslint": "^9.32.0",
         "eslint-plugin-import": "^2.31.0",
         "globals": "^17.7.0",
         "got": "^15.1.0",
         "husky": "^9.1.6",
-        "node-html-parser": "^9.0.0",
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3",
         "tough-cookie": "^6.0.2",
@@ -1919,13 +1917,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
@@ -2276,23 +2267,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -2303,19 +2277,6 @@
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^4.0.2"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -2504,63 +2465,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
     "node_modules/dompurify": {
       "version": "3.4.13",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
@@ -2569,21 +2473,6 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -2673,19 +2562,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5250,17 +5126,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/node-html-parser": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-9.0.0.tgz",
-      "integrity": "sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "^5.1.0",
-        "entities": "^8.0.0"
-      }
-    },
     "node_modules/node-readfiles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
@@ -5383,19 +5248,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oas-kit-common": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
     "test:contract": "docker compose -f compose.yml -f test/contract/compose.yml run --quiet-pull --pull always --build --rm contract-tests",
     "verify:schemata": "redocly lint src/routes/**/*-schema*.yml",
-    "test:contract:local": "dotenv -- ./test/contract/check-schema.sh"
+    "test:contract:local": "dotenv -- ./test/contract/check-schema.sh",
+    "generate:defraid-token": "dotenv -e .env -- node scripts/get-defra-id-token.js"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",
@@ -45,14 +46,12 @@
   "devDependencies": {
     "@redocly/cli": "1.29.0",
     "@vitest/coverage-v8": "4.1.9",
-    "acorn": "^8.16.0",
     "dotenv-cli": "^10.0.0",
     "eslint": "^9.32.0",
     "eslint-plugin-import": "^2.31.0",
     "globals": "^17.7.0",
     "got": "^15.1.0",
     "husky": "^9.1.6",
-    "node-html-parser": "^9.0.0",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3",
     "tough-cookie": "^6.0.2",

--- a/scripts/get-defra-id-token.js
+++ b/scripts/get-defra-id-token.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-import * as acorn from 'acorn'
 import got from 'got'
-import { parse as parseHtml } from 'node-html-parser'
 import crypto from 'node:crypto'
 import { CookieJar } from 'tough-cookie'
 
@@ -11,7 +9,7 @@ const UA =
 const MAX_ROUNDS = 8
 
 const REQUIRED_CONFIG = {
-  crn: 'CRN',
+  crn: 'DEFRA_ID_CRN',
   password: 'DEFRA_ID_PASSWORD',
   wellKnownUrl: 'DEFRA_ID_WELL_KNOWN_URL',
   clientId: 'DEFRA_ID_CLIENT_ID',
@@ -39,12 +37,15 @@ const readConfig = () => {
 }
 
 const cookieJar = new CookieJar()
+// The Defra ID hosts intermittently drop connections (timeouts, TLS resets); a short
+// pause and retry recovers these without restarting the whole journey. The journey's
+// POSTs are all safe to re-submit, so retry those too.
 const http = got.extend({
   cookieJar,
   methodRewriting: true,
   throwHttpErrors: false,
   maxRedirects: 20,
-  retry: { limit: 0 },
+  retry: { limit: 3, methods: ['GET', 'POST'] },
   headers: {
     'user-agent': UA,
     accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
@@ -60,32 +61,80 @@ const tryJson = (body) => {
 }
 
 const parseSettings = (html) => {
-  const script = parseHtml(html)
-    .querySelectorAll('script')
-    .find((el) => el.rawText.includes('var SETTINGS = {'))
-  if (!script) return null
-  let settings
-  try {
-    const declaration = acorn
-      .parse(script.rawText, { ecmaVersion: 'latest' })
-      .body.filter((node) => node.type === 'VariableDeclaration')
-      .flatMap((node) => node.declarations)
-      .find((node) => node.id.name === 'SETTINGS')
-    settings = JSON.parse(script.rawText.slice(declaration.init.start, declaration.init.end))
-  } catch {
-    return null
+  const marker = 'var SETTINGS = '
+  const start = html.indexOf(marker + '{')
+  if (start === -1) return null
+  const from = start + marker.length
+  // the SETTINGS object contains nested braces, so grow the slice one `}` at a
+  // time until it parses
+  for (let end = html.indexOf('}', from); end !== -1; end = html.indexOf('}', end + 1)) {
+    try {
+      const settings = JSON.parse(html.slice(from, end + 1))
+      return {
+        csrf: settings.csrf ?? null,
+        transId: settings.transId ?? null,
+        api: settings.api ?? null,
+        tenant: settings.hosts?.tenant ?? null,
+        policy: settings.hosts?.policy ?? null
+      }
+    } catch {
+      // not the closing brace yet - keep growing
+    }
   }
-  return {
-    csrf: settings.csrf ?? null,
-    transId: settings.transId ?? null,
-    api: settings.api ?? null,
-    tenant: settings.hosts?.tenant ?? null,
-    policy: settings.hosts?.policy ?? null
-  }
+  return null
 }
 
 const parseFieldIds = (html) =>
   [...html.matchAll(/"ID"\s*:\s*"([^"]*)"/g)].map((m) => m[1]).filter(Boolean)
+
+const inputValue = (html, name) =>
+  html.match(new RegExp(`<input[^>]*name="${name}"[^>]*value="([^"]*)"`))?.[1] ??
+  html.match(new RegExp(`<input[^>]*value="([^"]*)"[^>]*name="${name}"`))?.[1]
+
+// The business-picker page renders its options client-side, so replicate the call its
+// JS (idphub picker.js) makes: POST the page's prefilled claims to the idphub
+// user-relationships API, authorised with the page's prefilled bearer token.
+const firstRelationshipId = async (pickerPageHtml) => {
+  const pre = (id) =>
+    pickerPageHtml.match(
+      new RegExp(`"ID":\\s*"${id}"[^}]*?"PRE":\\s*"((?:[^"\\\\]|\\\\.)*)"`, 's')
+    )?.[1]
+  const remoteResource = pickerPageHtml.match(/"remoteResource"\s*:\s*"([^"]+)"/)?.[1]
+  const bearerToken = pre('bearerToken')
+  const fail = (reason) => {
+    throw new Error(
+      `Could not list this account's businesses (${reason}).\n` +
+        'Re-run with DEFRA_ID_RELATIONSHIP_ID set to pick one explicitly.'
+    )
+  }
+  if (!remoteResource || !bearerToken) fail('picker page had no remoteResource/bearerToken')
+
+  const fragment = await http.get(remoteResource)
+  const relationshipsUrl = fragment.body.match(/data-user-relationships-page="([^"]+)"/)?.[1]
+  if (!relationshipsUrl) fail('picker fragment had no user-relationships URL')
+
+  const payload = {
+    id: pre('objectId'),
+    serviceId: pre('serviceId'),
+    correlationId: pre('correlationId'),
+    sessionId: pre('sessionId'),
+    amr: new URL(remoteResource).searchParams.get('amr')
+  }
+  if (pre('dataStoreId')) payload.dataStoreId = pre('dataStoreId')
+  const res = await http.post(relationshipsUrl, {
+    headers: { Authorization: `Bearer ${bearerToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+  const relationships = tryJson(res.body).relationships
+  if (!res.ok || !relationships?.length) fail(`user-relationships returned HTTP ${res.statusCode}`)
+
+  const first = relationships[0]
+  console.error(
+    `DEFRA_ID_RELATIONSHIP_ID not set; defaulting to the first of ${relationships.length} ` +
+      `businesses: ${first.organisationName} (relationship ${first.id}, organisation ${first.organisationId})`
+  )
+  return first.id
+}
 
 const discoverEndpoints = async (wellKnownUrl) => {
   const oidc = await http(wellKnownUrl, { headers: { accept: 'application/json' } }).json()
@@ -96,6 +145,8 @@ const discoverEndpoints = async (wellKnownUrl) => {
   }
 }
 
+// Front door: idphub check-js gate, then relay the auto-POST callback to B2C;
+// returns the first B2C SelfAsserted page
 const passFrontDoor = async (authorizeEndpoint, b2cBase, config) => {
   const state = crypto.randomUUID()
   const authorizeUrl =
@@ -113,7 +164,7 @@ const passFrontDoor = async (authorizeEndpoint, b2cBase, config) => {
       p: config.policy
     })
   const gatePage = await http.get(authorizeUrl)
-  const crumb = parseHtml(gatePage.body).querySelector('input[name="crumb"]')?.getAttribute('value')
+  const crumb = inputValue(gatePage.body, 'crumb')
   if (!crumb) throw new Error('Did not reach the idphub check-js page (unexpected journey).')
 
   const checkJsUrl = new URL('/registration/journey/check-js/check-js-enabled', gatePage.url).href
@@ -121,10 +172,11 @@ const passFrontDoor = async (authorizeEndpoint, b2cBase, config) => {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded', Referer: checkJsUrl },
     body: new URLSearchParams({ crumb, checkJs: '' }).toString()
   })
-  const callbackForm = parseHtml(resumePage.body).querySelector('form[action*="authresp"]')
-  const callbackAction = callbackForm?.getAttribute('action')
-  const cbCode = callbackForm?.querySelector('input[name="code"]')?.getAttribute('value')
-  const cbState = callbackForm?.querySelector('input[name="state"]')?.getAttribute('value')
+  const callbackAction = resumePage.body
+    .match(/<form[^>]*action="([^"]*authresp[^"]*)"/)?.[1]
+    ?.replace(/&amp;/g, '&')
+  const cbCode = inputValue(resumePage.body, 'code')
+  const cbState = inputValue(resumePage.body, 'state')
   if (!callbackAction || !cbCode)
     throw new Error('idphub did not return a callback code (check-js gate failed).')
 
@@ -135,7 +187,73 @@ const passFrontDoor = async (authorizeEndpoint, b2cBase, config) => {
   return { page, state }
 }
 
-const completeSelfAssertedRounds = async (startPage, b2cBase, config) => {
+// what to submit for the current page: crn+password, business picker, or an
+// empty pre-step
+const stepBody = async (pageHtml, config) => {
+  const fields = parseFieldIds(pageHtml)
+  const body = new URLSearchParams({ request_type: 'RESPONSE' })
+  if (fields.includes('crn')) {
+    body.set('crn', config.crn)
+    body.set('password', config.password)
+  } else if (fields.includes('currentRelationshipId')) {
+    body.set(
+      'currentRelationshipId',
+      config.relationshipId || (await firstRelationshipId(pageHtml))
+    )
+  } else {
+    for (const field of fields) body.set(field, '')
+  }
+  return body
+}
+
+const submitStep = async (settings, body, b2cBase) => {
+  const saUrl = `${b2cBase}${settings.tenant}/SelfAsserted?tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`
+  const saRes = await http.post(saUrl, {
+    followRedirect: false,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+      'X-CSRF-TOKEN': settings.csrf,
+      'X-Requested-With': 'XMLHttpRequest',
+      Referer: `${b2cBase}${settings.tenant}/`
+    },
+    body: body.toString()
+  })
+  const saJson = tryJson(saRes.body)
+  if (!saRes.ok || (saJson.status && String(saJson.status) !== '200')) {
+    throw new Error(
+      `B2C rejected the step (HTTP ${saRes.statusCode}, status ${saJson.status ?? 'none'}): ` +
+        (saJson.message || saRes.body.slice(0, 200))
+    )
+  }
+}
+
+const confirmStep = (settings, b2cBase, appRedirect) =>
+  http.get(
+    `${b2cBase}${settings.tenant}/api/${settings.api}/confirmed?rememberMe=false&csrf_token=${settings.csrf}&tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`,
+    { followRedirect: (response) => !appRedirect(response) }
+  )
+
+const extractAuthCode = (redirectToApp, state) => {
+  const err = redirectToApp.searchParams.get('error')
+  if (err) {
+    throw new Error(
+      `Defra Identity returned error: ${err} - ${redirectToApp.searchParams.get('error_description') || ''}`
+    )
+  }
+  const code = redirectToApp.searchParams.get('code')
+  if (!code) {
+    throw new Error('Redirected back with neither a code nor an error (unexpected journey).')
+  }
+  const returnedState = redirectToApp.searchParams.get('state')
+  if (returnedState && returnedState !== state) {
+    throw new Error('State mismatch on redirect (possible CSRF).')
+  }
+  return code
+}
+
+// B2C SelfAsserted rounds: pre-step, crn+password, business picker (if shown);
+// returns the authorization code once B2C redirects back to the app
+const completeSelfAssertedRounds = async (startPage, b2cBase, state, config) => {
   let page = startPage
   const redirectOrigin = new URL(config.redirectUrl).origin
   const appRedirect = (response) => {
@@ -155,66 +273,11 @@ const completeSelfAssertedRounds = async (startPage, b2cBase, config) => {
             : 'Journey may have changed.')
       )
     }
-    const fields = parseFieldIds(page.body)
-    const body = new URLSearchParams({ request_type: 'RESPONSE' })
-    if (fields.includes('crn')) {
-      body.set('crn', config.crn)
-      body.set('password', config.password)
-    } else if (fields.includes('currentRelationshipId')) {
-      if (!config.relationshipId) {
-        throw new Error(
-          'This account has multiple businesses and pure-HTTP cannot list them\n' +
-            '(they are rendered client-side from a "picker" resource).\n' +
-            'Re-run with DEFRA_ID_RELATIONSHIP_ID set.'
-        )
-      }
-      body.set('currentRelationshipId', config.relationshipId)
-    } else {
-      for (const field of fields) body.set(field, '')
-    }
-
-    const saUrl = `${b2cBase}${settings.tenant}/SelfAsserted?tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`
-    const saRes = await http.post(saUrl, {
-      followRedirect: false,
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-        'X-CSRF-TOKEN': settings.csrf,
-        'X-Requested-With': 'XMLHttpRequest',
-        Referer: `${b2cBase}${settings.tenant}/`
-      },
-      body: body.toString()
-    })
-    const saJson = tryJson(saRes.body)
-    if (!saRes.ok || (saJson.status && String(saJson.status) !== '200')) {
-      throw new Error(
-        `B2C rejected the step (HTTP ${saRes.statusCode}, status ${saJson.status ?? 'none'}): ` +
-          (saJson.message || saRes.body.slice(0, 200))
-      )
-    }
-
-    const confirmedUrl = `${b2cBase}${settings.tenant}/api/${settings.api}/confirmed?rememberMe=false&csrf_token=${settings.csrf}&tx=${encodeURIComponent(settings.transId)}&p=${settings.policy}`
-    const confirmed = await http.get(confirmedUrl, {
-      followRedirect: (response) => !appRedirect(response)
-    })
+    await submitStep(settings, await stepBody(page.body, config), b2cBase)
+    const confirmed = await confirmStep(settings, b2cBase, appRedirect)
     const redirectToApp = appRedirect(confirmed)
-    if (!redirectToApp) {
-      page = confirmed
-      continue
-    }
-
-    const err = redirectToApp.searchParams.get('error')
-    if (err) {
-      throw new Error(
-        `Defra Identity returned error: ${err} - ${redirectToApp.searchParams.get('error_description') || ''}`
-      )
-    }
-    const code = redirectToApp.searchParams.get('code')
-    if (!code) {
-      throw new Error(
-        `Redirected to ${config.redirectUrl} with neither a code nor an error (unexpected journey).`
-      )
-    }
-    return { code, state: redirectToApp.searchParams.get('state') }
+    if (redirectToApp) return extractAuthCode(redirectToApp, state)
+    page = confirmed
   }
 
   throw new Error(`Completed ${MAX_ROUNDS} journey rounds without a redirect back to the app.`)
@@ -239,19 +302,20 @@ const redeemCode = async (tokenEndpoint, code, config) => {
       `Token endpoint failed: HTTP ${tokenRes.statusCode}\n${token.error || ''}: ${(token.error_description || '').split(/\r?\n/)[0]}`
     )
   }
-
-  return token.access_token || token.id_token
+  if (!token.access_token) {
+    throw new Error(
+      'Token endpoint returned no access_token (is the client id missing from the requested scope?)'
+    )
+  }
+  return token.access_token
 }
 
 const main = async () => {
   const config = readConfig()
   const { authorizeEndpoint, tokenEndpoint, b2cBase } = await discoverEndpoints(config.wellKnownUrl)
   const { page, state } = await passFrontDoor(authorizeEndpoint, b2cBase, config)
-  const captured = await completeSelfAssertedRounds(page, b2cBase, config)
-  if (captured.state && captured.state !== state)
-    throw new Error('State mismatch on redirect (possible CSRF).')
-
-  console.log(await redeemCode(tokenEndpoint, captured.code, config))
+  const code = await completeSelfAssertedRounds(page, b2cBase, state, config)
+  console.log(await redeemCode(tokenEndpoint, code, config))
 }
 
 main().catch((err) => {

--- a/src/common/helpers/fail-action.js
+++ b/src/common/helpers/fail-action.js
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { createLogger } from './logging/logger.js'
 
 const logger = createLogger()
@@ -55,10 +56,11 @@ export const emulateUpstreamErrors = (request, h) => {
       return h.response({ code, message: 'HTTP 422 ' }).code(code)
     }
     if (code === 500) {
+      const logId = randomBytes(8).toString('hex')
       return h
         .response({
           code,
-          message: 'There was an error processing your request. It has been logged (ID someID)'
+          message: `There was an error processing your request. It has been logged (ID ${logId}).`
         })
         .code(code)
     }

--- a/src/routes/kits-v1/land-schema.oas.yml
+++ b/src/routes/kits-v1/land-schema.oas.yml
@@ -34,18 +34,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ParcelNoGeometry'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
-          description: Returned by upstream if organisationId has an invalid format
+          description: Returned by upstream if organisationId or historicDate has an invalid format
           content:
             text/html:
               schema:
                 type: string
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
-          description: Returned by upstream if historicDate has an invalid format
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/InternalServerError'
 
   /lms/organisation/{organisationId}/parcel-details/historic/{historicDate}:
     get:
@@ -67,12 +67,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ParcelDetails'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           description: Returned by upstream if organisationId or historicDate has an invalid format
           content:
             text/html:
               schema:
                 type: string
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers:
     get:
@@ -102,12 +108,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CapdFeatureCollectionLandCovers'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           description: Returned by upstream if any of the parameters are badly formed
           content:
             text/html:
               schema:
                 type: string
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /lms/organisation/{organisationId}/covers-summary/historic/{historicDate}:
     get:
@@ -137,8 +149,12 @@ paths:
             text/html:
               schema:
                 type: string
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
-          description: Returned by upstream if org can't be found
+          description: |
+            Returned by upstream if org can't be found, or if historicDate cannot be
+            parsed as a date (see `InternalServerError`).
           content:
             application/json:
               schema:
@@ -184,13 +200,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/CapdFeatureCollectionParcel'
         '400':
-          description: Returned by upstream if bounding box is not supplied
+          description: |
+            Returned by upstream if bounding box is not supplied, or by upstream
+            infrastructure (proxy/Jetty) if the URI is malformed.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+            text/html:
+              schema:
+                type: string
         '404':
-          description: Returned by upstream if bounding box is not formatted correctly
+          description: |
+            Returned by upstream if bounding box is not formatted correctly, or if
+            organisationId overflows a Java Long (values above 9223372036854775807
+            that still pass the gateway's 19-digit limit).
           content:
             application/json:
               schema:
@@ -219,8 +243,14 @@ components:
       required: true
       description: |
         Date for historical data retrieval. Format: `DD-MMM-YY` date string (e.g. `19-Jul-24`).
+        The pattern documents the accepted shape - anything else is rejected before or by
+        upstream (proxy/Jetty 400/404 for URI garbage, app-level 403/500 otherwise).
       schema:
         type: string
+        # NOTE: [0-9] rather than \d - schemathesis generates via Python `re`,
+        # where \d matches any Unicode digit, and such dates 502 in the test
+        # proxy chain before ever reaching upstream
+        pattern: '^[0-9]{2}-[A-Za-z]{3}-[0-9]{2}$'
         examples: ['19-Jul-24']
     sheetId:
       name: sheetId
@@ -248,11 +278,50 @@ components:
   responses:
     BadRequest:
       description: |
-        Validation error
+        Returned by upstream infrastructure (proxy/Jetty) if the URI is malformed -
+        e.g. control characters, backslashes or empty path segments (`Bad Message 400`).
+      content:
+        text/html:
+          schema:
+            type: string
+          examples:
+            badRequest:
+              summary: Jetty bad message HTML response
+              value: |
+                <h1>Bad Message 400</h1><pre>reason: Ambiguous URI empty segment</pre>
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: |
+        Returned by upstream if organisationId overflows a Java Long (values above
+        9223372036854775807 that still pass the gateway's 19-digit limit), or if
+        path mangling (e.g. a `#` in a path parameter) leaves no matching route.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            notFound:
+              summary: JAX-RS not found response
+              value: { 'code': 404, 'message': 'HTTP 404 Not Found' }
+    InternalServerError:
+      description: |
+        Returned by upstream if historicDate matches the `DD-MMM-YY` pattern but cannot
+        be strictly parsed as a date - e.g. an unknown or non-exact-case month
+        abbreviation (`00-AAA-00`, `00-jul-24`) or a day outside 01-31 (`99-Jul-24`).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            internalServerError:
+              summary: Logged server error response
+              value:
+                {
+                  'code': 500,
+                  'message': 'There was an error processing your request. It has been logged (ID 7f693ddc6eef88a2).'
+                }
 
   schemas:
     ErrorResponse:

--- a/src/routes/kits-v1/land.js
+++ b/src/routes/kits-v1/land.js
@@ -1,3 +1,5 @@
+import Boom from '@hapi/boom'
+import { createLogger } from '../../common/helpers/logging/logger.js'
 import {
   retrieveCovers,
   retrieveCoversSummary,
@@ -5,16 +7,24 @@ import {
   retrieveParcelGeometries,
   retrieveParcels
 } from '../../factories/land/land.factory.js'
-import Boom from '@hapi/boom'
-import { createLogger } from '../../common/helpers/logging/logger.js'
 
 const logger = createLogger('land.route')
 
-const extractOrganisationId = (request) => {
+// Upstream's WAF only lets 1-19 digit organisationId path segments through.
+const ORGANISATION_ID_PATTERN = /^\d{1,19}$/
+
+// 19-digit values that overflow a Java Long fail upstream's path-param conversion with a plain 404
+const JAVA_LONG_MAX = 9223372036854775807n
+
+const extractOrganisationId = (request, { parseAsLong = true } = {}) => {
   const organisationId = request.params.organisationId
-  if (!Number.isInteger(Number(organisationId))) {
+  if (!ORGANISATION_ID_PATTERN.test(organisationId)) {
     logger.warn(`Badly formed organisation ID (${organisationId})`)
     throw Boom.forbidden()
+  }
+  if (parseAsLong && BigInt(organisationId) > JAVA_LONG_MAX) {
+    logger.warn(`Organisation ID overflows a Java Long (${organisationId})`)
+    throw Boom.notFound()
   }
   return organisationId
 }
@@ -47,10 +57,18 @@ const extractIncludeGeometries = (request) => {
 // Dates must have format DD-MMM-YY (e.g. 10-Jul-24)
 const HISTORIC_DATE_PATTERN = /^\d{2}-[A-Za-z]{3}-\d{2}$/
 
-const validateHistoricDate = (request, errorFunction) => {
+const PARSEABLE_DATE_PATTERN =
+  /^(0[1-9]|[12]\d|3[01])-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2}$/
+
+const validateHistoricDate = (request) => {
   const { historicDate } = request.params
   if (!HISTORIC_DATE_PATTERN.test(historicDate)) {
-    throw errorFunction()
+    logger.warn(`Badly formed historic date (${historicDate})`)
+    throw Boom.forbidden()
+  }
+  if (!PARSEABLE_DATE_PATTERN.test(historicDate)) {
+    logger.warn(`Unparseable historic date (${historicDate})`)
+    throw Boom.internal()
   }
 }
 
@@ -60,7 +78,7 @@ export const land = [
     path: '/lms/organisation/{organisationId}/parcels/historic/{historicDate}',
     handler: async (request, h) => {
       const organisationId = extractOrganisationId(request)
-      validateHistoricDate(request, Boom.internal)
+      validateHistoricDate(request)
 
       const parcels = retrieveParcels(organisationId)
       return h.response(parcels)
@@ -71,7 +89,7 @@ export const land = [
     path: '/lms/organisation/{organisationId}/parcel-details/historic/{historicDate}',
     handler: async (request, h) => {
       const organisationId = extractOrganisationId(request)
-      validateHistoricDate(request, Boom.forbidden)
+      validateHistoricDate(request)
 
       const parcelDetails = retrieveParcelDetails(organisationId)
       return h.response(parcelDetails)
@@ -83,7 +101,8 @@ export const land = [
     handler: async (request, h) => {
       const { sheetId, parcelId } = request.params
 
-      const organisationId = extractOrganisationId(request)
+      const organisationId = extractOrganisationId(request, { parseAsLong: false })
+      validateHistoricDate(request)
       const includeGeometries = extractIncludeGeometries(request)
 
       const covers = retrieveCovers(organisationId, sheetId, parcelId, includeGeometries)
@@ -95,7 +114,7 @@ export const land = [
     path: '/lms/organisation/{organisationId}/covers-summary/historic/{historicDate}',
     handler: async (request, h) => {
       const organisationId = extractOrganisationId(request)
-      validateHistoricDate(request, Boom.forbidden)
+      validateHistoricDate(request)
 
       const coversSummary = retrieveCoversSummary(organisationId)
       return h.response(coversSummary)

--- a/test/contract/check-schema.sh
+++ b/test/contract/check-schema.sh
@@ -32,7 +32,7 @@ usage() {
   echo "  KITS_INTERNAL_URL  - the URL of the KITS API to use (this should be the DAL Mock proxy endpoint, via the ephemeral endpoint)"
   echo "  CDP_API_KEY    - CDP Platform developer API key"
   echo "  DEFRA_ID_TOKEN - a pre-issued Defra Identity token; if unset one is generated"
-  echo "                   with scripts/get-defra-id-token.js, which needs CRN,"
+  echo "                   with scripts/get-defra-id-token.js, which needs DEFRA_ID_CRN,"
   echo "                   DEFRA_ID_PASSWORD and the DEFRA_ID_* client config (see .env.example)"
   echo "  KITS_EXTERNAL_URL - the URL of the KITS EXTERNAL proxy endpoint (defaults to"
   echo "                      the deployed mock's /proxy/external/extapi ephemeral route)"
@@ -50,12 +50,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Resolve the Defra ID token (generating one if needed) and default CRN/ORG_ID from
-# its claims.
+# Resolve the Defra ID token (generating one if needed) and default DEFRA_ID_CRN and
+# DEFRA_ID_RELATIONSHIP_ID (the example orgId) from its claims.
 resolve_defra_id_token() {
   if [ -z "${DEFRA_ID_TOKEN}" ]; then
-    if [ -z "${CRN}" ]; then
-      echo "ERROR: CRN (plus DEFRA_ID_PASSWORD and the DEFRA_ID_* config) must be set to generate a Defra Identity token" 1>&2
+    if [ -z "${DEFRA_ID_CRN}" ]; then
+      echo "ERROR: DEFRA_ID_CRN (plus DEFRA_ID_PASSWORD and the DEFRA_ID_* config) must be set to generate a Defra Identity token" 1>&2
       usage
       exit 1
     fi
@@ -70,8 +70,8 @@ resolve_defra_id_token() {
   claim() {
     node -p 'JSON.parse(Buffer.from(process.argv[2].split(".")[1], "base64url").toString())[process.argv[1]] ?? ""' "$1" "${DEFRA_ID_TOKEN}"
   }
-  CRN="${CRN:-$( claim contactId )}"
-  ORG_ID="${ORG_ID:-$( claim currentRelationshipId )}"
+  DEFRA_ID_CRN="${DEFRA_ID_CRN:-$( claim contactId )}"
+  ORG_ID="${DEFRA_ID_RELATIONSHIP_ID:-$( claim currentRelationshipId )}"
 }
 
 # check OPTION argument
@@ -210,8 +210,8 @@ elif [ "${gateway}" = "kits-external" ]; then # KITS EXTERNAL gateway
     usage
     exit 1
   fi
-  if [ -z "${CRN}" ]; then
-    echo "ERROR: CRN is not set and could not be derived from the Defra ID token" 1>&2
+  if [ -z "${DEFRA_ID_CRN}" ]; then
+    echo "ERROR: DEFRA_ID_CRN is not set and could not be derived from the Defra ID token" 1>&2
     usage
     exit 1
   fi
@@ -226,7 +226,7 @@ elif [ "${gateway}" = "kits-external" ]; then # KITS EXTERNAL gateway
       run /tmp/schema.json \
         --header "x-api-key: ${CDP_API_KEY}" \
         --header "Authorization: ${DEFRA_ID_TOKEN}" \
-        --header "crn: ${CRN}" \
+        --header "crn: ${DEFRA_ID_CRN}" \
         --exclude-checks=unsupported_method,not_a_server_error \
         --report-vcr-path /tmp/vcr.yaml \
         --url "${KITS_EXTERNAL_URL:-https://ephemeral-protected.api.dev.cdp-int.defra.cloud/fcp-dal-upstream-mock/proxy/external/extapi}"

--- a/test/contract/schemathesis.toml
+++ b/test/contract/schemathesis.toml
@@ -64,3 +64,21 @@ enabled = false
 
 # ======================= END OF =======================
 # ============== Bank submit / validate ================
+
+
+
+# ======================= START OF =======================
+# ================== Land land-covers ====================
+
+[[operations]]
+include-path = "/lms/organisation/{organisationId}/parcel/sheet-id/{sheetId}/parcel-id/{parcelId}/historic/{historicDate}/land-covers"
+include-method = "GET"
+
+# Skip: upstream never parses organisationId on this endpoint (200 even for values
+# overflowing a Java Long) and ignores junk includeGeometries values/extra query
+# params, so schema-invalid requests are still served.
+[operations.checks.negative_data_rejection]
+enabled = false
+
+# ======================= END OF =======================
+# ================== Land land-covers ==================

--- a/test/integration/routes/kits-v1/land-queries.test.js
+++ b/test/integration/routes/kits-v1/land-queries.test.js
@@ -1,4 +1,5 @@
 import Hapi from '@hapi/hapi'
+import { emulateUpstreamErrors } from '../../../../src/common/helpers/fail-action.js'
 import { land } from '../../../../src/routes/kits-v1/land.js'
 import { loadSchema } from '../../../../src/utils/validatePayload.js'
 
@@ -7,6 +8,7 @@ describe('Land routes', () => {
   beforeAll(async () => {
     server = Hapi.server()
     server.route(land)
+    server.ext('onPreResponse', emulateUpstreamErrors)
     await Promise.all([
       server.initialize(),
       loadSchema('/routes/kits-v1/land-schema.oas.yml').then((s) => (schema = s))
@@ -55,13 +57,39 @@ describe('Land routes', () => {
       expect(statusCode).toBe(403)
     })
 
-    test('should return 500 if supplied historicDate is invalid', async () => {
+    test('should return 404 if organisationId overflows a Java Long', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/lms/organisation/9223372036854775808/parcels/historic/01-Jan-25'
+      })
+      expect(statusCode).toBe(404)
+      expect(result).toEqual({ code: 404, message: 'HTTP 404 Not Found' })
+    })
+
+    test('should return 403 if supplied historicDate is badly formed', async () => {
       const { statusCode } = await server.inject({
         method: 'GET',
         url: '/lms/organisation/111111111/parcels/historic/invalid'
       })
-      expect(statusCode).toBe(500)
+      expect(statusCode).toBe(403)
     })
+
+    test.each([['00-AAA-00'], ['00-jul-24'], ['99-Jul-24']])(
+      'should return 500 if historicDate matches the pattern but cannot be parsed (%s)',
+      async (historicDate) => {
+        const { result, statusCode } = await server.inject({
+          method: 'GET',
+          url: `/lms/organisation/111111111/parcels/historic/${historicDate}`
+        })
+        expect(statusCode).toBe(500)
+        expect(result).toEqual({
+          code: 500,
+          message: expect.stringMatching(
+            /^There was an error processing your request\. It has been logged \(ID [0-9a-f]{16}\)\.$/
+          )
+        })
+      }
+    )
 
     test('should not return data where land is defined AND empty in id-lookups for the organisation', async () => {
       const { result, statusCode } = await server.inject({
@@ -173,6 +201,31 @@ describe('Land routes', () => {
       expect(statusCode).toBe(403)
     })
 
+    test('should return 200 even if organisationId overflows a Java Long (upstream never parses it)', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/lms/organisation/9223372036854775808/parcel/sheet-id/SS6627/parcel-id/5662/historic/01-Mar-25/land-covers'
+      })
+      expect(statusCode).toBe(200)
+      expect(result.type).toBe('FeatureCollection')
+    })
+
+    test('should return 403 if historicDate is badly formed', async () => {
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: '/lms/organisation/111111111/parcel/sheet-id/SS6627/parcel-id/5662/historic/invalid/land-covers'
+      })
+      expect(statusCode).toBe(403)
+    })
+
+    test('should return 500 if historicDate matches the pattern but cannot be parsed', async () => {
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: '/lms/organisation/111111111/parcel/sheet-id/SS6627/parcel-id/5662/historic/00-AAA-00/land-covers'
+      })
+      expect(statusCode).toBe(500)
+    })
+
     test('should treat includeGeometries=null as false', async () => {
       const { result, statusCode } = await server.inject({
         method: 'GET',
@@ -267,12 +320,24 @@ describe('Land routes', () => {
       })
     })
 
-    test('should return 403 if organisationId is not numeric', async () => {
-      const { statusCode } = await server.inject({
+    test.each([['nonexistent'], ['0.0'], ['1e5'], ['0x10'], ['-5'], ['99999999999999999999']])(
+      'should return 403 if organisationId is not 1-19 digits (%s)',
+      async (organisationId) => {
+        const { statusCode } = await server.inject({
+          method: 'GET',
+          url: `/lms/organisation/${organisationId}/geometries?bbox=0,0,0,0`
+        })
+        expect(statusCode).toBe(403)
+      }
+    )
+
+    test('should return 404 if organisationId overflows a Java Long', async () => {
+      const { result, statusCode } = await server.inject({
         method: 'GET',
-        url: '/lms/organisation/nonexistent/geometries?bbox=0,0,0,0'
+        url: '/lms/organisation/9223372036854775808/geometries?bbox=0,0,0,0'
       })
-      expect(statusCode).toBe(403)
+      expect(statusCode).toBe(404)
+      expect(result).toEqual({ code: 404, message: 'HTTP 404 Not Found' })
     })
 
     test('should return 400 if bounding box is missing', async () => {

--- a/test/unit/common/helpers/fail-action.test.js
+++ b/test/unit/common/helpers/fail-action.test.js
@@ -1,4 +1,5 @@
-import { failAction } from '../../../../src/common/helpers/fail-action.js'
+import Boom from '@hapi/boom'
+import { emulateUpstreamErrors, failAction } from '../../../../src/common/helpers/fail-action.js'
 
 describe('#fail-action', () => {
   test('Should throw expected error', () => {
@@ -9,5 +10,51 @@ describe('#fail-action', () => {
     expect(() => failAction(mockRequest, mockToolkit, mockError)).toThrow(
       'Something terrible has happened!'
     )
+  })
+})
+
+describe('#emulateUpstreamErrors', () => {
+  const mockToolkit = {
+    response: (payload) => ({ code: (statusCode) => ({ payload, statusCode }) }),
+    continue: Symbol('continue')
+  }
+  const mockRequest = (response) => ({
+    headers: {},
+    info: { id: 'test-id' },
+    method: 'get',
+    path: '/test',
+    payload: null,
+    response
+  })
+
+  test('Should pass non-Boom responses through', () => {
+    const result = emulateUpstreamErrors(mockRequest({ isBoom: false }), mockToolkit)
+    expect(result).toBe(mockToolkit.continue)
+  })
+
+  test('Should replace a 404 with the upstream JAX-RS envelope', () => {
+    const { payload, statusCode } = emulateUpstreamErrors(mockRequest(Boom.notFound()), mockToolkit)
+    expect(statusCode).toBe(404)
+    expect(payload).toEqual({ code: 404, message: 'HTTP 404 Not Found' })
+  })
+
+  test('Should replace a 403 with the upstream WAF HTML page', () => {
+    const { payload, statusCode } = emulateUpstreamErrors(
+      mockRequest(Boom.forbidden()),
+      mockToolkit
+    )
+    expect(statusCode).toBe(403)
+    expect(payload).toContain('<h1>403 Forbidden</h1>')
+  })
+
+  test('Should replace a 500 with the upstream logged-error envelope', () => {
+    const { payload, statusCode } = emulateUpstreamErrors(mockRequest(Boom.internal()), mockToolkit)
+    expect(statusCode).toBe(500)
+    expect(payload).toEqual({
+      code: 500,
+      message: expect.stringMatching(
+        /^There was an error processing your request\. It has been logged \(ID [0-9a-f]{16}\)\.$/
+      )
+    })
   })
 })


### PR DESCRIPTION
Updates:
- Dropped the acorn and node-html-parser dev dependencies
- Select business if customer has multiple businesses. Or if set override using env var `DEFRA_ID_RELATIONSHIP_ID`
- Added retries (limit 3, GET and POST)
- `CRN` → `DEFRA_ID_CRN` and `ORG_ID` → `DEFRA_ID_RELATIONSHIP_ID`. Now all external-gateway config shares the `DEFRA_ID_` prefix.
- `DEFRA_ID_RELATIONSHIP_ID` is now populated from the token's `currentRelationshipId` claim, or defaulted to the first business when generating).                                                                 
- New npm script `generate:defraid-token` to generate a token standalone via .env.
- .env.example restructured to document the two external-test modes explicitly.

To test external endpoints by generating a fresh token you need to populate the `DEFRA_ID_` envs ( found in password manager ):
```
  KITS_EXTERNAL_URL=
  
  DEFRA_ID_WELL_KNOWN_URL=
  DEFRA_ID_CLIENT_ID=
  DEFRA_ID_CLIENT_SECRET=
  DEFRA_ID_SERVICE_ID=
  DEFRA_ID_POLICY=
  DEFRA_ID_REDIRECT_URL=
  
  DEFRA_ID_CRN=
  DEFRA_ID_PASSWORD=
```

Or, you can specify a token with the following env vars:
```
  KITS_EXTERNAL_URL=
  
  DEFRA_ID_TOKEN=
```