### PR TITLE
fix: make validateEmail only check validated emails

### DIFF
--- a/src/factories/id-lookups.js
+++ b/src/factories/id-lookups.js
@@ -37,6 +37,16 @@ export const staticPersonData = {
     title: null,
     otherTitle: null
   },
+  11111121: {
+    // static data overrides example - duplicate email that is NOT validated
+    crn: '1111112100',
+    firstName: 'Baby',
+    middleName: null,
+    lastName: 'Skeleton',
+    email: 'unvalidated@the-closet.net',
+    emailValidated: false,
+    confirmed: true
+  },
   // Person in org 333333333
   11111120: {
     crn: '1111111901',

--- a/src/routes/kits-v1/person.js
+++ b/src/routes/kits-v1/person.js
@@ -69,7 +69,9 @@ export const person = [
     path: '/person/{email}/validateEmail',
     handler: async (request, h) => {
       const email = request.params.email.toLowerCase()
-      const emailDuplicated = allPeople().some((person) => person.email?.toLowerCase() === email)
+      const emailDuplicated = allPeople().some(
+        (person) => person.email?.toLowerCase() === email && person.emailValidated
+      )
       return h.response({ _data: { emailDuplicated } })
     }
   },

--- a/test/integration/routes/kits-v1/person/person.test.js
+++ b/test/integration/routes/kits-v1/person/person.test.js
@@ -64,6 +64,15 @@ describe('Person routes', () => {
       expect(statusCode).toBe(200)
       expect(result).toEqual({ _data: { emailDuplicated: false } })
     })
+
+    it('should not report a duplicate when the matching person has not validated their email', async () => {
+      const { result, statusCode } = await server.inject({
+        method: 'GET',
+        url: '/person/unvalidated@the-closet.net/validateEmail'
+      })
+      expect(statusCode).toBe(200)
+      expect(result).toEqual({ _data: { emailDuplicated: false } })
+    })
   })
 
   it('should GET a person conforming to the schema', async () => {


### PR DESCRIPTION
* fix: validateEmail now only checks for matching customer emails if the address is validated

This fixes/resolves/relates to Jira ticket: [FCPDAL-122]

[FCPDAL-122]: https://eaflood.atlassian.net/browse/FCPDAL-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ